### PR TITLE
feat(课程表): 添加导入成功后自动设置当前教学周功能 (#52)

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -533,5 +533,8 @@
         "placeholders": {
             "version": {"type": "String"}
         }
-    }
+    },
+    "autoSetCurrentWeekTitle": "Auto-set Current Teaching Week",
+    "autoSetCurrentWeekContent": "Fetch the current teaching week from the academic system and set it automatically?",
+    "autoSetCurrentWeekSuccess": "Current teaching week set automatically"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3072,6 +3072,24 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Agreed version v{version}'**
   String eulaAgreedVersion(String version);
+
+  /// No description provided for @autoSetCurrentWeekTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Auto-set Current Teaching Week'**
+  String get autoSetCurrentWeekTitle;
+
+  /// No description provided for @autoSetCurrentWeekContent.
+  ///
+  /// In en, this message translates to:
+  /// **'Fetch the current teaching week from the academic system and set it automatically?'**
+  String get autoSetCurrentWeekContent;
+
+  /// No description provided for @autoSetCurrentWeekSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'Current teaching week set automatically'**
+  String get autoSetCurrentWeekSuccess;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1570,4 +1570,15 @@ class AppLocalizationsEn extends AppLocalizations {
   String eulaAgreedVersion(String version) {
     return 'Agreed version v$version';
   }
+
+  @override
+  String get autoSetCurrentWeekTitle => 'Auto-set Current Teaching Week';
+
+  @override
+  String get autoSetCurrentWeekContent =>
+      'Fetch the current teaching week from the academic system and set it automatically?';
+
+  @override
+  String get autoSetCurrentWeekSuccess =>
+      'Current teaching week set automatically';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1529,6 +1529,15 @@ class AppLocalizationsZh extends AppLocalizations {
   String eulaAgreedVersion(String version) {
     return '已同意版本 v$version';
   }
+
+  @override
+  String get autoSetCurrentWeekTitle => '自动设置当前教学周';
+
+  @override
+  String get autoSetCurrentWeekContent => '是否从教务系统获取当前教学周并自动设置？';
+
+  @override
+  String get autoSetCurrentWeekSuccess => '已自动设置当前教学周';
 }
 
 /// The translations for Chinese, as used in China, using the Han script (`zh_Hans_CN`).

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -531,5 +531,8 @@
         "placeholders": {
             "version": {"type": "String"}
         }
-    }
+    },
+    "autoSetCurrentWeekTitle": "自动设置当前教学周",
+    "autoSetCurrentWeekContent": "是否从教务系统获取当前教学周并自动设置？",
+    "autoSetCurrentWeekSuccess": "已自动设置当前教学周"
 }

--- a/lib/pages/course/import_schedule_page.dart
+++ b/lib/pages/course/import_schedule_page.dart
@@ -364,6 +364,54 @@ class _ImportSchedulePageState extends State<ImportSchedulePage> {
         ScaffoldMessenger.of(
           context,
         ).showSnackBar(SnackBar(content: Text(l10n.importSuccess)));
+
+        // 导入成功后，询问是否自动设置当前教学周
+        final setWeek = await showDialog<bool>(
+          context: context,
+          builder: (ctx) => AlertDialog(
+            title: Text(l10n.autoSetCurrentWeekTitle),
+            content: Text(l10n.autoSetCurrentWeekContent),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(ctx, false),
+                child: Text(l10n.cancel),
+              ),
+              TextButton(
+                onPressed: () => Navigator.pop(ctx, true),
+                child: Text(l10n.confirm),
+              ),
+            ],
+          ),
+        );
+        if (setWeek == true && mounted) {
+          try {
+            final week = await authProvider.service.fetchCurrentWeek();
+            if (!mounted) return;
+            final now = DateTime.now();
+            final today = DateTime(now.year, now.month, now.day);
+            final currentSunday = today.toSunday();
+            final newStartDate = currentSunday.subtract(
+              Duration(days: (week - 1) * 7),
+            );
+            final currentConfig =
+                widget.courseProvider.scheduleConfig.value;
+            final updatedConfig = currentConfig.copyWith(
+              semesterStartDate: newStartDate,
+            );
+            await widget.courseProvider
+                .updateScheduleConfig(updatedConfig);
+            if (mounted) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: Text(l10n.autoSetCurrentWeekSuccess),
+                ),
+              );
+            }
+          } catch (_) {
+            // 获取失败不阻断流程，静默忽略
+          }
+        }
+
         if (Navigator.of(logicRootContext).canPop()) {
           Navigator.of(logicRootContext).pop();
         }


### PR DESCRIPTION
在导入课程表成功后，询问用户是否从教务系统获取当前教学周并自动设置学期开始日期。添加了相关的中英文翻译文本，并在用户确认后调用接口获取教学周信息，计算并更新学期开始日期。