### PR TITLE
fix: 将 CCYL Token 从 SharedPreferences 迁移到 FlutterSecureStorage

### DIFF
--- a/lib/injection/injector.dart
+++ b/lib/injection/injector.dart
@@ -67,7 +67,7 @@ void _configureAsyncDependencies() {
   getIt.registerSingletonAsync<CcylProvider>(() async {
     await getIt.isReady<SharedPreferences>();
     final prefs = getIt<SharedPreferences>();
-    return CcylProvider(prefs);
+    return CcylProvider.create(prefs);
   });
   getIt.registerSingletonAsync<GradesProvider>(() async {
     await getIt.isReady<SharedPreferences>();

--- a/lib/providers/ccyl_provider.dart
+++ b/lib/providers/ccyl_provider.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:bugaoshan/providers/secure_storage_provider.dart';
 import 'package:bugaoshan/services/ccyl_oauth_service.dart';
 import 'package:bugaoshan/services/ccyl_service.dart';
 
@@ -8,11 +10,16 @@ const _keyCcylUserId = 'ccyl_user_id';
 
 class CcylProvider extends ChangeNotifier {
   final SharedPreferences _prefs;
+  final FlutterSecureStorage _secure;
   final CcylService _service = CcylService();
 
-  CcylProvider(this._prefs) {
-    _token = _prefs.getString(_keyCcylToken);
-    final userId = _prefs.getString(_keyCcylUserId);
+  CcylProvider(this._prefs) : _secure = SecureStorageProvider.instance {
+    _initFromSecureStorage();
+  }
+
+  Future<void> _initFromSecureStorage() async {
+    _token = await _secure.read(key: _keyCcylToken);
+    final userId = await _secure.read(key: _keyCcylUserId);
     if (_token != null) {
       _service.restoreToken(_token!, userId);
     }
@@ -27,9 +34,9 @@ class CcylProvider extends ChangeNotifier {
   Future<void> loginWithOAuthCode(String code) async {
     await _service.login(code);
     _token = _service.token;
-    await _prefs.setString(_keyCcylToken, _token!);
+    await _secure.write(key: _keyCcylToken, value: _token!);
     if (_service.currentUser != null) {
-      await _prefs.setString(_keyCcylUserId, _service.currentUser!.id);
+      await _secure.write(key: _keyCcylUserId, value: _service.currentUser!.id);
       debugPrint('Saved userId: ${_service.currentUser!.id}');
     }
     debugPrint(
@@ -41,8 +48,8 @@ class CcylProvider extends ChangeNotifier {
   void logout() {
     _service.logout();
     _token = null;
-    _prefs.remove(_keyCcylToken);
-    _prefs.remove(_keyCcylUserId);
+    _secure.delete(key: _keyCcylToken);
+    _secure.delete(key: _keyCcylUserId);
     notifyListeners();
   }
 

--- a/lib/providers/ccyl_provider.dart
+++ b/lib/providers/ccyl_provider.dart
@@ -13,8 +13,13 @@ class CcylProvider extends ChangeNotifier {
   final FlutterSecureStorage _secure;
   final CcylService _service = CcylService();
 
-  CcylProvider(this._prefs) : _secure = SecureStorageProvider.instance {
-    _initFromSecureStorage();
+  CcylProvider._(this._prefs, this._secure);
+
+  static Future<CcylProvider> create(SharedPreferences prefs) async {
+    final secure = SecureStorageProvider.instance;
+    final provider = CcylProvider._(prefs, secure);
+    await provider._initFromSecureStorage();
+    return provider;
   }
 
   Future<void> _initFromSecureStorage() async {
@@ -53,7 +58,6 @@ class CcylProvider extends ChangeNotifier {
     notifyListeners();
   }
 
-  /// 统一认证重新登录后，自动恢复二课登录状态
   Future<void> reLogin() async {
     try {
       final oauthCode = await CcylOAuthService().getOAuthCode();


### PR DESCRIPTION
## 修复内容

解决 Issue #75: CCYL Token 存储在 SharedPreferences (明文)

### 问题
CcylProvider 将 `ccyl_token` 和 `ccyl_user_id` 存储在 SharedPreferences，在 Android 上以明文 XML 保存，存在被恶意应用读取的风险。

### 解决方案
改用项目已有的 `SecureStorageProvider`（底层使用 FlutterSecureStorage）：
- iOS: Keychain（first_unlock_this_device）
- Android: EncryptedSharedPreferences

### 改动
- `lib/providers/ccyl_provider.dart`: 改用 `SecureStorageProvider.instance` 读写 token 和 userId
- `loginWithOAuthCode` / `logout` / `_initFromSecureStorage` 均使用 secure storage

### 兼容性
- 旧 SharedPreferences 中的数据不再读取（首次登录会重新 oauth）
- 如果需要平滑迁移，可后续添加一次性迁移逻辑