### PR TITLE
fix: 修复多项已确认的代码问题

### DIFF
--- a/lib/pages/campus/downloads/file_utils.dart
+++ b/lib/pages/campus/downloads/file_utils.dart
@@ -47,6 +47,16 @@ String formatDate(DateTime date) {
   return '$y-$m-$d';
 }
 
+String sanitizeDownloadFileName(String rawName) {
+  final normalized = rawName.replaceAll('\\', '/');
+  var fileName = p.posix.basename(normalized).trim();
+  if (fileName.isEmpty || fileName == '.' || fileName == '..') {
+    fileName = 'download';
+  }
+  fileName = fileName.replaceAll(RegExp(r'[<>:"/\\|?*\x00-\x1F]'), '_');
+  return fileName.isEmpty ? 'download' : fileName;
+}
+
 /// Downloads a file from [url] into `Bugaoshan/{dirName}/`.
 /// Returns the final local path.
 Future<String> downloadFile(
@@ -73,7 +83,7 @@ Future<String> downloadFile(
   final bytes = response.bodyBytes;
 
   // Prefer filename from Content-Disposition header.
-  var actualFileName = fileName;
+  var actualFileName = sanitizeDownloadFileName(fileName);
   final cd = response.headers['content-disposition'];
   if (cd != null) {
     // RFC 5987: filename*=UTF-8''percent-encoded-value
@@ -82,13 +92,15 @@ Future<String> downloadFile(
       caseSensitive: false,
     ).firstMatch(cd);
     if (rfc5987 != null) {
-      actualFileName = Uri.decodeComponent(rfc5987.group(1)!);
+      actualFileName = sanitizeDownloadFileName(
+        Uri.decodeComponent(rfc5987.group(1)!),
+      );
     } else {
       final fnMatch = RegExp(
         r'''filename\s*=\s*["']?([^"';]+)["']?''',
       ).firstMatch(cd);
       if (fnMatch != null) {
-        actualFileName = fnMatch.group(1)!;
+        actualFileName = sanitizeDownloadFileName(fnMatch.group(1)!);
       }
     }
   }
@@ -119,11 +131,12 @@ Future<String?> checkDownloadedFile(String dirName, String fileName) async {
   final saveDir = Directory('${base.path}/Bugaoshan/$dirName');
   if (!saveDir.existsSync()) return null;
 
-  final exactPath = '${saveDir.path}/$fileName';
+  final safeFileName = sanitizeDownloadFileName(fileName);
+  final exactPath = '${saveDir.path}/$safeFileName';
   if (File(exactPath).existsSync()) return exactPath;
 
-  final baseName = p.basenameWithoutExtension(fileName);
-  final ext = p.extension(fileName);
+  final baseName = p.basenameWithoutExtension(safeFileName);
+  final ext = p.extension(safeFileName);
   for (var i = 1; i <= 99; i++) {
     final variantPath = '${saveDir.path}/$baseName ($i)$ext';
     if (File(variantPath).existsSync()) return variantPath;

--- a/lib/pages/campus/notice/webview_notice_page.dart
+++ b/lib/pages/campus/notice/webview_notice_page.dart
@@ -142,9 +142,11 @@ class _WebViewNoticePageState extends State<WebViewNoticePage> {
       } catch (e) {
         debugPrint('${widget.debugLabel} beautify script error: $e');
       }
-      await controller.evaluateJavascript(source: _domReadyScript);
-      // DOMReady handler will invoke _finishLoading after JS finishes.
-      return;
+      if (_domReadyScript.isNotEmpty) {
+        await controller.evaluateJavascript(source: _domReadyScript);
+        // DOMReady handler will invoke _finishLoading after JS finishes.
+        return;
+      }
     }
     await _finishLoading();
   }

--- a/lib/pages/course/import_schedule_page.dart
+++ b/lib/pages/course/import_schedule_page.dart
@@ -106,6 +106,7 @@ class _ImportSchedulePageState extends State<ImportSchedulePage> {
       }
 
       config.id = DateTime.now().millisecondsSinceEpoch.toString();
+      _validateImportedSchedule(config, courses);
 
       // For share mode, check for conflict. For jwxt, we already got a name from user.
       if (widget.mode == ImportMode.share) {
@@ -352,6 +353,7 @@ class _ImportSchedulePageState extends State<ImportSchedulePage> {
         final config = parsed.config;
         config.semesterName = scheduleName;
         config.id = DateTime.now().millisecondsSinceEpoch.toString();
+        _validateImportedSchedule(config, parsed.courses);
 
         if (widget.courseProvider.isScheduleNameTaken(config.semesterName)) {
           config.semesterName =
@@ -519,6 +521,25 @@ class _ImportSchedulePageState extends State<ImportSchedulePage> {
     config.showWeekend = hasWeekend;
 
     return (config: config, courses: courses);
+  }
+
+  void _validateImportedSchedule(ScheduleConfig config, List<Course> courses) {
+    if (config.totalWeeks < 1 || config.timeSlots.isEmpty) {
+      throw const FormatException('Invalid schedule config');
+    }
+    final maxSection = config.timeSlots.length;
+    for (final course in courses) {
+      if (course.startWeek < 1 ||
+          course.endWeek < course.startWeek ||
+          course.endWeek > config.totalWeeks ||
+          course.dayOfWeek < 1 ||
+          course.dayOfWeek > 7 ||
+          course.startSection < 1 ||
+          course.endSection < course.startSection ||
+          course.endSection > maxSection) {
+        throw FormatException('Invalid course range: ${course.name}');
+      }
+    }
   }
 
   @override

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -93,11 +93,13 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
     }
   }
 
-  void _updateWidget() {
+  Future<void> _updateWidget() async {
     if (!kIsWeb && Platform.isAndroid) {
       try {
-        getIt<WidgetUpdateService>().updateWidgetData();
-      } catch (_) {}
+        await getIt<WidgetUpdateService>().updateWidgetData();
+      } catch (e) {
+        debugPrint('Widget update failed: $e');
+      }
     }
   }
 

--- a/lib/providers/scu_auth_provider.dart
+++ b/lib/providers/scu_auth_provider.dart
@@ -29,15 +29,16 @@ class ScuAuthProvider extends ChangeNotifier {
 
   ScuAuthProvider(this._prefs) {
     _loginTimestamp = _prefs.getInt(_keyLoginTimestamp);
-    _updateLastAppOpenTimestamp();
   }
 
   Future<void> init() async {
     _accessToken = await SecureStorageProvider.instance.read(
       key: _keyAccessToken,
     );
+    _service.restoreAccessToken(_accessToken);
     _userRealname = _prefs.getString(_keyUserRealname);
     _userNumber = _prefs.getString(_keyUserNumber);
+    await _updateLastAppOpenTimestamp();
   }
 
   String? _accessToken;
@@ -55,7 +56,10 @@ class ScuAuthProvider extends ChangeNotifier {
     final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
     if (now - _loginTimestamp! > _sessionDurationSeconds) return true;
     final lastAppOpen = _prefs.getInt(_keyLastAppOpenTimestamp);
-    if (lastAppOpen != null && _loginTimestamp! < lastAppOpen) return true;
+    if (lastAppOpen != null &&
+        lastAppOpen - _loginTimestamp! > _sessionDurationSeconds) {
+      return true;
+    }
     return false;
   }
 

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -114,7 +114,7 @@ class DatabaseService {
 
       // Read schedules list
       final schedulesRaw = metadataBox.get(_keySchedules) as List<dynamic>?;
-      final currentId =
+      var currentId =
           metadataBox.get(_keyCurrentScheduleId) as String? ?? 'default';
 
       List<ScheduleConfig> schedules = [];
@@ -150,6 +150,10 @@ class DatabaseService {
         }
       }
 
+      if (!schedules.any((s) => s.id == currentId)) {
+        currentId = schedules.first.id;
+      }
+
       // Insert schedules into SQLite
       for (final s in schedules) {
         await _db.insert('schedules', {
@@ -165,6 +169,7 @@ class DatabaseService {
       });
 
       // Migrate courses from each Hive box
+      final migratedCourseIds = <String>{};
       for (final s in schedules) {
         final boxName = s.id == 'default' ? 'courses' : 'courses_${s.id}';
         try {
@@ -174,7 +179,12 @@ class DatabaseService {
             if (value is Map) {
               final courseMap = Map<String, dynamic>.from(value);
               final course = Course.fromJson(courseMap);
-              await _db.insert('courses', _courseToRow(course, s.id));
+              final safeCourse =
+                  course.id.isEmpty || migratedCourseIds.contains(course.id)
+                  ? _copyCourseWithFreshId(course)
+                  : course;
+              migratedCourseIds.add(safeCourse.id);
+              await _db.insert('courses', _courseToRow(safeCourse, s.id));
             }
           }
           await box.close();
@@ -261,6 +271,21 @@ class DatabaseService {
       weekType: weekTypeIndex < WeekType.values.length
           ? WeekType.values[weekTypeIndex]
           : WeekType.every,
+    );
+  }
+
+  Course _copyCourseWithFreshId(Course course) {
+    return Course(
+      name: course.name,
+      teacher: course.teacher,
+      location: course.location,
+      startWeek: course.startWeek,
+      endWeek: course.endWeek,
+      dayOfWeek: course.dayOfWeek,
+      startSection: course.startSection,
+      endSection: course.endSection,
+      colorValue: course.colorValue,
+      weekType: course.weekType,
     );
   }
 

--- a/lib/services/scu_auth_service.dart
+++ b/lib/services/scu_auth_service.dart
@@ -28,6 +28,11 @@ class ScuAuthService {
   CookieClient? _cachedClient;
   Future<CookieClient>? _bindSessionFuture;
 
+  void restoreAccessToken(String? token) {
+    _accessToken = token;
+    _cachedClient = null;
+  }
+
   /// 获取验证码，返回 [CaptchaResult]
   Future<CaptchaResult> fetchCaptcha() async {
     final ts = DateTime.now().millisecondsSinceEpoch;

--- a/lib/services/update_service.dart
+++ b/lib/services/update_service.dart
@@ -287,17 +287,17 @@ class UpdateService {
         ? TarDecoder().decodeBytes(GZipDecoder().decodeBytes(chunks))
         : ZipDecoder().decodeBytes(chunks);
     final extractDirObj = Directory(extractDir);
-    if (extractDirObj.existsSync()) {
-      extractDirObj.deleteSync(recursive: true);
+    if (await extractDirObj.exists()) {
+      await extractDirObj.delete(recursive: true);
     }
-    extractDirObj.createSync(recursive: true);
-    final extractRoot = extractDirObj.resolveSymbolicLinksSync();
+    await extractDirObj.create(recursive: true);
+    final extractRoot = await extractDirObj.resolveSymbolicLinks();
     for (final file in archive) {
       final filename = _safeArchivePath(extractRoot, file.name);
       if (file.isFile) {
         final outFile = File(filename);
-        outFile.parent.createSync(recursive: true);
-        outFile.writeAsBytesSync(file.content as List<int>);
+        await outFile.parent.create(recursive: true);
+        await outFile.writeAsBytes(file.content as List<int>);
       }
     }
 

--- a/lib/services/update_service.dart
+++ b/lib/services/update_service.dart
@@ -291,9 +291,9 @@ class UpdateService {
       extractDirObj.deleteSync(recursive: true);
     }
     extractDirObj.createSync(recursive: true);
+    final extractRoot = extractDirObj.resolveSymbolicLinksSync();
     for (final file in archive) {
-      final sanitizedName = file.name.replaceAll('/', Platform.pathSeparator);
-      final filename = p.join(extractDir, sanitizedName);
+      final filename = _safeArchivePath(extractRoot, file.name);
       if (file.isFile) {
         final outFile = File(filename);
         outFile.parent.createSync(recursive: true);
@@ -315,6 +315,25 @@ class UpdateService {
     }
 
     exit(0);
+  }
+
+  String _safeArchivePath(String extractRoot, String entryName) {
+    final normalizedName = entryName.replaceAll('\\', '/');
+    if (normalizedName.split('/').any((part) => part == '..')) {
+      throw FormatException('Unsafe archive entry: $entryName');
+    }
+    final relativePath = p.fromUri(Uri(path: normalizedName));
+    if (p.isAbsolute(relativePath)) {
+      throw FormatException('Unsafe archive entry: $entryName');
+    }
+    final fullPath = p.normalize(p.join(extractRoot, relativePath));
+    final rootWithSeparator = extractRoot.endsWith(Platform.pathSeparator)
+        ? extractRoot
+        : '$extractRoot${Platform.pathSeparator}';
+    if (fullPath != extractRoot && !fullPath.startsWith(rootWithSeparator)) {
+      throw FormatException('Unsafe archive entry: $entryName');
+    }
+    return fullPath;
   }
 
   Future<void> _installAndroid(List<int> apkBytes, String version) async {


### PR DESCRIPTION
## Summary

- 修复 SCU 登录状态恢复不一致：`init()` 时同步 token 到 `ScuAuthService`，修正 `lastAppOpen` 过期判断逻辑
- 修复附件下载路径穿越风险：统一 `sanitizeDownloadFileName`，覆盖所有文件名来源
- 修复更新包解压 Zip Slip 风险：`_safeArchivePath` 校验 `..`、绝对路径、最终路径前缀
- 修复非法课表导入后 ICS 导出崩溃：导入时校验 `totalWeeks`、`timeSlots`、课程周次/星期/节次范围
- 修复旧 Hive 数据迁移边界问题：无效 `currentScheduleId` 自动回落、空/重复 course id 重新生成
- 修复 WebView 首次加载可能卡 loading：`_domReadyScript` 为空时直接 `finishLoading`
- 修复 Android 小组件更新异步异常未捕获：`_updateWidget` 改为 async 并记录日志

## Test plan

- [ ] 冷启动后确认登录状态正确恢复，不出现"需要重新登录"
- [ ] 下载附件时使用含 `../` 或特殊字符的文件名，确认写入安全路径
- [ ] 桌面端检查更新功能正常，解压不报错
- [ ] 分享/在线导入一份含非法节次的课表，确认被拒绝而非静默入库
- [ ] 从旧版本 Hive 数据迁移到 SQLite，确认课表和课程完整
- [ ] WebView 通知页首次加载不卡在 loading 遮罩