### PR TITLE
feat: 默认不创建课表，无课表时显示空状态

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -138,6 +138,9 @@
     "scheduleSetting":"Schedule Setting",
     "scheduleManagement":"Schedule Management",
     "globalSetting":"Global Setting",
+    "noSchedule":"No schedule yet",
+    "noScheduleHint":"Import or create a schedule to get started",
+    "addSchedule":"Add Schedule",
 
     "addCourse":"Add Course",
     "editCourse":"Edit Course",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -781,6 +781,24 @@ abstract class AppLocalizations {
   /// **'Global Setting'**
   String get globalSetting;
 
+  /// No description provided for @noSchedule.
+  ///
+  /// In en, this message translates to:
+  /// **'No schedule yet'**
+  String get noSchedule;
+
+  /// No description provided for @noScheduleHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Import or create a schedule to get started'**
+  String get noScheduleHint;
+
+  /// No description provided for @addSchedule.
+  ///
+  /// In en, this message translates to:
+  /// **'Add Schedule'**
+  String get addSchedule;
+
   /// No description provided for @addCourse.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -371,6 +371,15 @@ class AppLocalizationsEn extends AppLocalizations {
   String get globalSetting => 'Global Setting';
 
   @override
+  String get noSchedule => 'No schedule yet';
+
+  @override
+  String get noScheduleHint => 'Import or create a schedule to get started';
+
+  @override
+  String get addSchedule => 'Add Schedule';
+
+  @override
   String get addCourse => 'Add Course';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -360,6 +360,15 @@ class AppLocalizationsZh extends AppLocalizations {
   String get globalSetting => '全局设置';
 
   @override
+  String get noSchedule => '暂无课表';
+
+  @override
+  String get noScheduleHint => '导入或新建一个课表开始使用';
+
+  @override
+  String get addSchedule => '新建课表';
+
+  @override
   String get addCourse => '添加课程';
 
   @override

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -137,6 +137,9 @@
     "scheduleSetting":"课表设置",
     "scheduleManagement":"课表管理",
     "globalSetting":"全局设置",
+    "noSchedule":"暂无课表",
+    "noScheduleHint":"导入或新建一个课表开始使用",
+    "addSchedule":"新建课表",
 
     "addCourse":"添加课程",
     "editCourse":"编辑课程",

--- a/lib/pages/course/course_page.dart
+++ b/lib/pages/course/course_page.dart
@@ -125,12 +125,7 @@ class _CoursePageState extends State<CoursePage> with WidgetsBindingObserver {
                 listenable: courseDataListenable,
                 builder: (context, _) => courseProvider.hasSchedule
                     ? _buildCourseGrid(context, null)
-                    : _NoScheduleView(
-                        onOpenManagement: () =>
-                            _openScheduleManagement(context),
-                        onImport: _onImport,
-                        onAddSchedule: () => _openAddScheduleDialog(context),
-                      ),
+                    : _buildNoScheduleView(context, null),
               ),
               ValueListenableBuilder<bool>(
                 valueListenable: courseProvider.isLoading,
@@ -197,6 +192,14 @@ class _CoursePageState extends State<CoursePage> with WidgetsBindingObserver {
           onEmptyTap: _onEmptyTap,
         );
       },
+    );
+  }
+
+  Widget _buildNoScheduleView(BuildContext context, Widget? _) {
+    return _NoScheduleView(
+      onOpenManagement: () => _openScheduleManagement(context),
+      onImport: _onImport,
+      onAddSchedule: () => _openAddScheduleDialog(context),
     );
   }
 

--- a/lib/pages/course/course_page.dart
+++ b/lib/pages/course/course_page.dart
@@ -6,6 +6,7 @@ import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/models/course.dart';
 import 'package:bugaoshan/pages/course/course_edit_page.dart';
 import 'package:bugaoshan/pages/course/import_schedule_page.dart';
+import 'package:bugaoshan/pages/course/schedule_management_page.dart';
 import 'package:bugaoshan/providers/app_config_provider.dart';
 import 'package:bugaoshan/providers/course_provider.dart';
 import 'package:bugaoshan/widgets/course/course_detail_sheet.dart';
@@ -17,6 +18,7 @@ import 'package:bugaoshan/utils/export_schedule_utils.dart';
 part 'course_page_swipe_page_view.dart';
 part 'course_page_top_bar.dart';
 part 'course_page_actions.dart';
+part 'course_page_no_schedule_view.dart';
 
 class CoursePage extends StatefulWidget {
   const CoursePage({super.key});
@@ -88,6 +90,7 @@ class _CoursePageState extends State<CoursePage> with WidgetsBindingObserver {
       courseProvider.courses,
       courseProvider.scheduleConfig,
       courseProvider.currentWeek,
+      courseProvider.allSchedules,
     ]);
     final bgImageListenable = Listenable.merge([
       appConfig.backgroundImagePath,
@@ -120,7 +123,14 @@ class _CoursePageState extends State<CoursePage> with WidgetsBindingObserver {
               ),
               ListenableBuilder(
                 listenable: courseDataListenable,
-                builder: _buildCourseGrid,
+                builder: (context, _) => courseProvider.hasSchedule
+                    ? _buildCourseGrid(context, null)
+                    : _NoScheduleView(
+                        onOpenManagement: () =>
+                            _openScheduleManagement(context),
+                        onImport: _onImport,
+                        onAddSchedule: () => _openAddScheduleDialog(context),
+                      ),
               ),
               ValueListenableBuilder<bool>(
                 valueListenable: courseProvider.isLoading,
@@ -131,6 +141,14 @@ class _CoursePageState extends State<CoursePage> with WidgetsBindingObserver {
         ),
       ],
     );
+  }
+
+  void _openScheduleManagement(BuildContext context) {
+    popupOrNavigate(context, const ScheduleManagementPage());
+  }
+
+  void _openAddScheduleDialog(BuildContext context) {
+    promptForNewScheduleConfig(context, courseProvider);
   }
 
   Widget _buildBackgroundImage(BuildContext context, Widget? _) {

--- a/lib/pages/course/course_page_no_schedule_view.dart
+++ b/lib/pages/course/course_page_no_schedule_view.dart
@@ -1,0 +1,92 @@
+part of 'course_page.dart';
+
+/// 课表为空时显示的占位视图：图标 + 「暂无课表」+ 「课表管理」/「导入课表」/「新建课表」按钮。
+class _NoScheduleView extends StatelessWidget {
+  final VoidCallback onOpenManagement;
+  final VoidCallback onImport;
+  final VoidCallback onAddSchedule;
+
+  const _NoScheduleView({
+    required this.onOpenManagement,
+    required this.onImport,
+    required this.onAddSchedule,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+
+    return Center(
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 32),
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 360),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              // 圆形 tint 图标背景，跟 wizard 流程的视觉语言一致
+              Container(
+                width: 96,
+                height: 96,
+                decoration: BoxDecoration(
+                  color: colorScheme.primaryContainer,
+                  shape: BoxShape.circle,
+                ),
+                child: Icon(
+                  Icons.calendar_month_outlined,
+                  size: 48,
+                  color: colorScheme.onPrimaryContainer,
+                ),
+              ),
+              const SizedBox(height: 20),
+              Text(
+                l10n.noSchedule,
+                style: textTheme.titleLarge?.copyWith(
+                  fontWeight: FontWeight.w600,
+                ),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                l10n.noScheduleHint,
+                style: textTheme.bodyMedium?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                ),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 28),
+              SizedBox(
+                width: double.infinity,
+                child: FilledButton.icon(
+                  onPressed: onOpenManagement,
+                  icon: const Icon(Icons.list_alt_rounded),
+                  label: Text(l10n.scheduleManagement),
+                ),
+              ),
+              const SizedBox(height: 10),
+              SizedBox(
+                width: double.infinity,
+                child: OutlinedButton.icon(
+                  onPressed: onImport,
+                  icon: const Icon(Icons.download_rounded),
+                  label: Text(l10n.importSchedule),
+                ),
+              ),
+              const SizedBox(height: 10),
+              SizedBox(
+                width: double.infinity,
+                child: OutlinedButton.icon(
+                  onPressed: onAddSchedule,
+                  icon: const Icon(Icons.add),
+                  label: Text(l10n.addSchedule),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/course/import_schedule_page.dart
+++ b/lib/pages/course/import_schedule_page.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/models/course.dart';
-import 'package:bugaoshan/providers/app_config_provider.dart';
 import 'package:bugaoshan/providers/course_provider.dart';
 import 'package:bugaoshan/providers/scu_auth_provider.dart';
 import 'package:bugaoshan/services/scu_auth_service.dart';
@@ -364,15 +363,6 @@ class _ImportSchedulePageState extends State<ImportSchedulePage> {
         await widget.courseProvider.addSchedule(config);
         for (final course in parsed.courses) {
           await widget.courseProvider.addCourse(course);
-        }
-      }
-
-      // 首次引导尚未完成且默认课表为空 → 删除默认课表
-      if (!getIt<AppConfigProvider>().firstLaunchWizardCompleted.value) {
-        final defaultCourses = await widget.courseProvider
-            .getCoursesForSchedule('default');
-        if (defaultCourses.isEmpty) {
-          await widget.courseProvider.deleteSchedule('default');
         }
       }
 

--- a/lib/pages/course/schedule_management_page.dart
+++ b/lib/pages/course/schedule_management_page.dart
@@ -8,6 +8,58 @@ import 'package:bugaoshan/widgets/dialog/dialog.dart';
 import 'package:bugaoshan/widgets/route/router_utils.dart';
 import 'package:bugaoshan/utils/export_schedule_utils.dart';
 
+/// 弹窗让用户输入新课表名称，校验重名后通过 [courseProvider.addSchedule] 添加。
+/// 复用当前选中的课表配置（timeSlots 等）作为模板。
+/// 供 [ScheduleManagementPage] 的 AppBar `+` 按钮和 [CoursePage] 空状态视图调用。
+Future<void> promptForNewScheduleConfig(
+  BuildContext context,
+  CourseProvider courseProvider,
+) async {
+  final l10n = AppLocalizations.of(context)!;
+  final controller = TextEditingController();
+  final newName = await showDialog<String>(
+    context: context,
+    builder: (ctx) => AlertDialog(
+      title: Text(l10n.semesterName),
+      content: TextField(
+        controller: controller,
+        autofocus: true,
+        decoration: InputDecoration(hintText: l10n.semesterName),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(ctx),
+          child: Text(l10n.cancel),
+        ),
+        TextButton(
+          onPressed: () {
+            final t = controller.text.trim();
+            if (t.isNotEmpty) Navigator.pop(ctx, t);
+          },
+          child: Text(l10n.save),
+        ),
+      ],
+    ),
+  );
+
+  if (newName == null || newName.isEmpty) return;
+  if (!context.mounted) return;
+
+  if (courseProvider.isScheduleNameTaken(newName)) {
+    showInfoDialog(title: l10n.duplicateScheduleName, content: '');
+    return;
+  }
+
+  // 复用当前选中的课表配置（timeSlots 等）作为模板
+  final currentConfig = courseProvider.scheduleConfig.value;
+  final newConfig = currentConfig.copyWith(
+    id: DateTime.now().millisecondsSinceEpoch.toString(),
+    semesterName: newName,
+    semesterStartDate: DateTime.now().toMonday(),
+  );
+  await courseProvider.addSchedule(newConfig);
+}
+
 class ScheduleManagementPage extends StatelessWidget {
   const ScheduleManagementPage({super.key});
 
@@ -108,59 +160,8 @@ class ScheduleManagementPage extends StatelessWidget {
             ),
             IconButton(
               icon: const Icon(Icons.add),
-              onPressed: () async {
-                final controller = TextEditingController();
-                final newName = await showDialog<String>(
-                  context: context,
-                  builder: (context) => AlertDialog(
-                    title: Text(l10n.semesterName),
-                    content: TextField(
-                      controller: controller,
-                      autofocus: true,
-                      decoration: InputDecoration(hintText: l10n.semesterName),
-                    ),
-                    actions: [
-                      TextButton(
-                        onPressed: () => Navigator.pop(context),
-                        child: Text(l10n.cancel),
-                      ),
-                      TextButton(
-                        onPressed: () {
-                          final text = controller.text.trim();
-                          if (text.isNotEmpty) {
-                            Navigator.pop(context, text);
-                          } else {
-                            // Could optionally show a small snackbar/hint here
-                            Navigator.pop(context);
-                          }
-                        },
-                        child: Text(l10n.save),
-                      ),
-                    ],
-                  ),
-                );
-
-                if (newName != null && newName.isNotEmpty) {
-                  if (courseProvider.isScheduleNameTaken(newName)) {
-                    if (context.mounted) {
-                      showInfoDialog(
-                        title: l10n.duplicateScheduleName,
-                        content: '',
-                      );
-                    }
-                    return;
-                  }
-
-                  // 复用当前选中的课表配置（TimeSlot 等）
-                  final currentConfig = courseProvider.scheduleConfig.value;
-                  final newConfig = currentConfig.copyWith(
-                    id: DateTime.now().millisecondsSinceEpoch.toString(),
-                    semesterName: newName,
-                    semesterStartDate: DateTime.now().toMonday(),
-                  );
-                  await courseProvider.addSchedule(newConfig);
-                }
-              },
+              onPressed: () =>
+                  promptForNewScheduleConfig(context, courseProvider),
             ),
           ],
         ),

--- a/lib/providers/course_provider.dart
+++ b/lib/providers/course_provider.dart
@@ -21,6 +21,9 @@ class CourseProvider {
   final ValueNotifier<int> currentWeek = ValueNotifier<int>(1);
   final ValueNotifier<bool> isLoading = ValueNotifier<bool>(false);
 
+  /// 当前数据库中是否存在课表。UI 据此在「暂无课表」空状态和 grid 之间切换。
+  bool get hasSchedule => allSchedules.value.isNotEmpty;
+
   static ScheduleConfig _defaultConfig() {
     final now = DateTime.now();
     return ScheduleConfig(
@@ -38,7 +41,12 @@ class CourseProvider {
       allSchedules.value = _db.getAllSchedules();
       final config = _db.getScheduleConfig();
       scheduleConfig.value = config;
-      currentWeek.value = config.getCurrentWeek();
+      // 无课表时 currentWeek 兜底为 1，避免占位 config 算出意外的周数
+      if (allSchedules.value.isEmpty) {
+        currentWeek.value = 1;
+      } else {
+        currentWeek.value = config.getCurrentWeek();
+      }
     } catch (e) {
       debugPrint('CourseProvider: failed to load data: $e');
     } finally {

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -16,9 +16,11 @@ class DatabaseService {
   late Database _db;
 
   // In-memory cache to support synchronous read methods
-  String _currentScheduleId = 'default';
+  String _currentScheduleId = '';
   List<ScheduleConfig> _schedulesCache = [];
   List<Course> _coursesCache = [];
+
+  bool get hasSchedule => _schedulesCache.isNotEmpty;
 
   Future<void> init() async {
     final dir = await getApplicationSupportDirectory();
@@ -73,19 +75,9 @@ class DatabaseService {
       _currentScheduleId = metaRows.first['value'] as String;
     }
 
-    // Ensure a default schedule exists
-    final scheduleRows = await _db.query('schedules');
-    if (scheduleRows.isEmpty) {
-      final defaultConfig = _defaultScheduleConfig();
-      await _db.insert('schedules', {
-        'id': defaultConfig.id,
-        'config_json': _encodeJson(defaultConfig.toJson()),
-      });
-      await _db.insert('metadata', {
-        'key': _keyCurrentScheduleId,
-        'value': 'default',
-      });
-    }
+    // 不再自动创建默认课表。新安装的 schedules 表为空，
+    // _currentScheduleId 保持 '' 直到用户切换到一个真实课表。
+    // 老用户：schedules 表非空，上面加载的 _currentScheduleId 继续生效。
 
     // Load caches
     await _loadSchedulesCache();
@@ -143,14 +135,14 @@ class DatabaseService {
             }
             schedules.add(config);
           } catch (_) {
-            schedules.add(_defaultScheduleConfig());
+            // 旧数据无法解析，迁移到空 schedules 表。
           }
-        } else {
-          schedules.add(_defaultScheduleConfig());
         }
+        // 不再为「无 legacy 数据」的情况自动插入默认课表。
+        // 老用户没课表就保持空，让 UI 显示「暂无课表」空状态。
       }
 
-      if (!schedules.any((s) => s.id == currentId)) {
+      if (schedules.isNotEmpty && !schedules.any((s) => s.id == currentId)) {
         currentId = schedules.first.id;
       }
 
@@ -294,6 +286,11 @@ class DatabaseService {
   String getCurrentScheduleId() => _currentScheduleId;
 
   Future<void> switchSchedule(String scheduleId) async {
+    // 未知 id 早返回，避免把空 '' 写进 metadata 并触发 courses 缓存重载。
+    if (_schedulesCache.indexWhere((s) => s.id == scheduleId) < 0) {
+      debugPrint('DatabaseService.switchSchedule: unknown id $scheduleId');
+      return;
+    }
     _currentScheduleId = scheduleId;
     await _db.update(
       'metadata',
@@ -307,6 +304,7 @@ class DatabaseService {
   List<ScheduleConfig> getAllSchedules() => List.unmodifiable(_schedulesCache);
 
   ScheduleConfig getScheduleConfig() {
+    if (_schedulesCache.isEmpty) return _placeholderScheduleConfig();
     return _schedulesCache.firstWhere(
       (s) => s.id == _currentScheduleId,
       orElse: () => _schedulesCache.first,
@@ -353,9 +351,20 @@ class DatabaseService {
 
     await _loadSchedulesCache();
 
-    // If we deleted the current one, switch to the first available
-    if (_currentScheduleId == scheduleId && _schedulesCache.isNotEmpty) {
-      await switchSchedule(_schedulesCache.first.id);
+    // 如果删的是当前课表：剩余 → 切到第一个；不剩 → 清空 currentScheduleId
+    if (_currentScheduleId == scheduleId) {
+      if (_schedulesCache.isNotEmpty) {
+        await switchSchedule(_schedulesCache.first.id);
+      } else {
+        _currentScheduleId = '';
+        await _db.update(
+          'metadata',
+          {'value': ''},
+          where: 'key = ?',
+          whereArgs: [_keyCurrentScheduleId],
+        );
+        await _loadCoursesCache();
+      }
     }
   }
 
@@ -371,11 +380,19 @@ class DatabaseService {
   }
 
   Future<void> addCourse(Course course) async {
+    if (_currentScheduleId.isEmpty) {
+      debugPrint('DatabaseService.addCourse: no current schedule');
+      return;
+    }
     await _db.insert('courses', _courseToRow(course, _currentScheduleId));
     await _loadCoursesCache();
   }
 
   Future<void> updateCourse(Course course) async {
+    if (_currentScheduleId.isEmpty) {
+      debugPrint('DatabaseService.updateCourse: no current schedule');
+      return;
+    }
     await _db.update(
       'courses',
       _courseToRow(course, _currentScheduleId),
@@ -409,33 +426,25 @@ class DatabaseService {
   // ==================== Clear ====================
 
   Future<void> clearAllCourseData() async {
-    final defaultConfig = _defaultScheduleConfig();
     await _db.transaction((txn) async {
       await txn.delete('courses');
       await txn.delete('schedules');
       await txn.delete('metadata');
-      await txn.insert('schedules', {
-        'id': defaultConfig.id,
-        'config_json': _encodeJson(defaultConfig.toJson()),
-      });
-      await txn.insert('metadata', {
-        'key': _keyCurrentScheduleId,
-        'value': 'default',
-      });
     });
-    _currentScheduleId = 'default';
-
-    await _loadSchedulesCache();
-    await _loadCoursesCache();
+    _currentScheduleId = '';
+    _schedulesCache = [];
+    _coursesCache = [];
   }
 
   // ==================== Helpers ====================
 
-  ScheduleConfig _defaultScheduleConfig() {
+  /// 占位用 ScheduleConfig，仅在 _schedulesCache 为空时返回，
+  /// 用于周次/总周数等算术保护，**不会**被持久化。
+  ScheduleConfig _placeholderScheduleConfig() {
     final now = DateTime.now();
     return ScheduleConfig(
-      id: 'default',
-      semesterName: '默认课表',
+      id: '',
+      semesterName: '',
       semesterStartDate: now.toMonday(),
       totalWeeks: 20,
     );


### PR DESCRIPTION
## Summary

把"自动创建默认课表"改成"按需创建"，并在课表为空时显示「暂无课表」空状态，引导用户主动导入或新建。

## Background

`DatabaseService.init()` 之前会在 schedules 表为空时自动插入一条 `id='default'` 的默认课表。这条空课表在大多数场景下都没用武之地，只能在「首次引导 → JWXT 导入」成功时被 commit 6a0b34a 的兜底逻辑清掉。本次改动把这件事前移到源头：数据库从一开始就不创建默认课表，UI 把「无课表」作为一等状态展示。

## Changes

- **`lib/services/database_service.dart`**
  - `_currentScheduleId` 默认值从 `'default'` 改为 `''`
  - `init()` 删除自动建表块；新增 `bool get hasSchedule`
  - `getScheduleConfig()` 空缓存返回 `_placeholderScheduleConfig()`（不再抛 `StateError`）
  - `switchSchedule()` 守卫未知 id 早返回
  - `deleteSchedule()` 删最后一条时把 `_currentScheduleId` 重置为 `''`
  - `clearAllCourseData()` 不再回插默认课表
  - Hive 迁移：删掉 `schedules.add(_defaultScheduleConfig())` 兜底
  - `addCourse`/`updateCourse` 在无当前课表时早返回
  - 删除 `_defaultScheduleConfig()`，新增 `_placeholderScheduleConfig()`（仅算术保护用）
- **`lib/providers/course_provider.dart`**
  - 新增 `bool get hasSchedule => allSchedules.value.isNotEmpty;`
  - `_loadData()` 无课表时 `currentWeek` 兜底为 1
- **`lib/pages/course/course_page.dart`** 扩 listenable 加 `allSchedules`；分支渲染 grid vs `_NoScheduleView`；新增 `_openScheduleManagement` / `_openAddScheduleDialog` 成员方法
- **`lib/pages/course/course_page_no_schedule_view.dart`**（新文件，part of）空状态视图：圆形 tint 图标 + 标题 + 副标题 + 3 个全宽按钮（课表管理 / 导入课表 / 新建课表）
- **`lib/pages/course/schedule_management_page.dart`** 抽离顶层函数 `promptForNewScheduleConfig()`，课表管理页和空状态视图共用
- **`lib/pages/course/import_schedule_page.dart`** 删除 commit 6a0b34a 的孤儿清理逻辑（不再需要）+ 删 `AppConfigProvider` import
- **l10n**：新增 `noSchedule` / `noScheduleHint` / `addSchedule`

## Verification

1. 全新安装 → 课表页直接显示「暂无课表」+ 三个按钮，TopBar「第 1 周」
2. 课表管理 → 列表为空
3. 从空状态点「课表管理」→ 弹窗/全屏进入 ScheduleManagementPage
4. 从空状态点「导入课表」→ 走分享 / JWXT 粘贴 / JWXT 联机任一流程 → 创建后 grid 出现
5. 从空状态点「新建课表」→ 弹窗输入名称 → 创建后 grid 出现
6. 软件设置 → 清除所有数据 → 落到空状态
7. 老用户（升级前已有 `default` 课表）：`schedules` 表非空，新逻辑不会触发，数据无损