### PR TITLE
feat: 支持鼠标侧键 X1 触发 Navigator 后退

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -10,6 +10,7 @@ import 'package:bugaoshan/pages/wizard/wizard_page.dart';
 import 'package:bugaoshan/providers/app_config_provider.dart';
 import 'package:bugaoshan/services/background_cache_service.dart';
 import 'package:bugaoshan/widgets/eula_content.dart';
+import 'package:bugaoshan/widgets/route/mouse_back_handler.dart';
 import 'package:bugaoshan/widgets/route/router_utils.dart';
 import 'package:system_theme/system_theme.dart';
 import 'l10n/app_localizations.dart';
@@ -69,6 +70,7 @@ class _MyAppState extends State<MyApp> {
       ]),
       builder: (context, _) => MaterialApp(
         navigatorKey: navigatorKey,
+        builder: (context, child) => MouseBackHandler(child: child!),
         locale: _appConfig.locale.value,
         onGenerateTitle: (ctx) => AppLocalizations.of(ctx)!.bugaoshan,
         localizationsDelegates: AppLocalizations.localizationsDelegates,

--- a/lib/widgets/route/mouse_back_handler.dart
+++ b/lib/widgets/route/mouse_back_handler.dart
@@ -1,0 +1,76 @@
+import 'dart:io' show Platform;
+
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/gestures.dart' show kBackMouseButton;
+import 'package:flutter/material.dart';
+
+import 'router_utils.dart' show navigatorKey;
+
+/// 全局拦截鼠标侧键 X1（[kBackMouseButton]），按下时调用
+/// [NavigatorState.maybePop]，使后退行为与 Android 系统返回键一致：
+/// - 子页：被 `Navigator.push` 推入的 route 被 pop；
+/// - 栈底（首页 / EULA / 引导）：[NavigatorState.maybePop] 返回 `false`，无操作；
+/// - `PopScope(canPop: false)` 的页面静默拦截；
+/// - 自带 `onPopInvokedWithResult` 的页面（如 `classroom_page`、`webview_notice_page`）
+///   走页面自身的"后退"逻辑；
+/// - 嵌套 Navigator（如 `popupOrNavigate` 在宽屏 dialog 内的 `Fragment`
+///   子导航）会先 pop 最深一层的 route，到 Fragment 初始页后再退回
+///   root 关闭 dialog。
+///
+/// 故意不处理 X2（`kForwardMouseButton`）——应用内多数页面没有对称的
+/// "前进"路径，盲目实现会破坏 [PopScope] 拦截语义与用户预期。
+///
+/// 仅在桌面端（Windows / Linux / macOS）与 Web 上激活；移动端为
+/// `child` 透传，零行为变化。
+class MouseBackHandler extends StatelessWidget {
+  const MouseBackHandler({super.key, required this.child});
+
+  final Widget child;
+
+  static bool get _isSupported {
+    if (kIsWeb) return true;
+    return Platform.isWindows || Platform.isLinux || Platform.isMacOS;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_isSupported) return child;
+    return Listener(
+      behavior: HitTestBehavior.translucent,
+      onPointerDown: (event) {
+        if ((event.buttons & kBackMouseButton) == 0) return;
+        _handleBack();
+      },
+      child: child,
+    );
+  }
+
+  void _handleBack() {
+    final rootState = navigatorKey.currentState;
+    if (rootState == null) return;
+    final target = _topmostNavigator() ?? rootState;
+
+    if (!identical(target, rootState) && !target.canPop()) {
+      // 嵌套 Navigator（典型：宽屏 dialog 内 `Fragment` 的初始页）已经
+      // 没有可 pop 的 route；退回 root 把 dialog 关掉，与 Android
+      // 系统返回键的语义一致。
+      rootState.maybePop();
+    } else {
+      // 交给 maybePop：会尊重 PopScope（`canPop: false` 静默拦截、
+      // `onPopInvokedWithResult` 走页面自身逻辑），并在栈底时无副作用。
+      target.maybePop();
+    }
+  }
+
+  /// 通过当前焦点定位最顶层的 [NavigatorState]。
+  ///
+  /// Flutter 在 `showDialog` / `Navigator.push` 时会默认把焦点移动到
+  /// 新 route 的第一个可 focus widget，所以 `primaryFocus` 通常就在
+  /// 用户当前正在交互的最深 Navigator 内。找不到焦点上下文时返回
+  /// `null`，由调用方退回 root。
+  NavigatorState? _topmostNavigator() {
+    final focusContext = FocusManager.instance.primaryFocus?.context;
+    if (focusContext == null) return null;
+    return Navigator.maybeOf(focusContext);
+  }
+}


### PR DESCRIPTION
## 背景

Web 浏览器通常把鼠标 X1 侧键映射为"后退"、X2 映射为"前进"。本应用目前没有拦截这两类事件——只能通过 AppBar / 系统返回键触发导航。

本 PR 在桌面端（Windows / Linux / macOS）与 Web 上接入 X1 侧键的"后退"语义；**不响应 X2 前进键**——应用内多数页面（详情页 / WebView / 二级视图）没有对称的"前进"路径，盲目实现会破坏 `PopScope` 拦截语义与用户预期。

## 改动

- **新增** `lib/widgets/route/mouse_back_handler.dart` — 全局 `Listener`，在 `onPointerDown` 中检测 `kBackMouseButton` 并调用 `Navigator.maybePop()`
- **修改** `lib/app.dart` — 在 `MaterialApp.builder` 中挂入 `MouseBackHandler`，位于 `Navigator` 之上，覆盖所有 route

### 关键设计

| 决策 | 理由 |
|---|---|
| `MaterialApp.builder` 挂 `Listener` | 比包 `home:` 覆盖面更广；与项目里"全局一次配置"的位置风格一致 |
| `FocusManager.primaryFocus` 反查最顶层 Navigator | 处理 `popupOrNavigate` 宽屏 dialog 内 `Fragment` 子导航的嵌套场景——优先 pop 最深的 Navigator，已无 route 时退回 root 关闭 dialog |
| 平台守卫：桌面 + Web | 移动端没有侧键，零行为变化；沿用 `lib/main.dart:52-55` 模板 |
| 不引入 settings 开关 | 保持最小改动 |

## 行为矩阵

| 场景 | 行为 |
|---|---|
| 桌面小屏子页 → 后退 | 子页被 pop |
| 桌面大屏 dialog 初始页 → 后退 | dialog 关闭 |
| 桌面大屏 dialog 子页 → 后退 | Fragment 子页先 pop，**第二次**后退才关闭 dialog |
| `PopScope(canPop: false)` 页面（EULA、引导） | 静默拦截 |
| 自定义 `onPopInvokedWithResult`（`classroom_page`、`webview_notice_page`） | 走页面自身逻辑 |
| 栈底（首页） | 无操作 |
| 移动端 | 零行为变化 |

## 验证

`flutter analyze` 全项目通过，无新增 warning。

桌面端手动验证清单：

1. **基础栈 pop**：首页 → 课表详情 → X1 后退 → 返回首页
2. **栈底无操作**：在首页直接按 X1 → 无反应
3. **`PopScope` 拦截**：冷启动停在 EULA 门 → X1 → 无反应
4. **`classroom_page` 自定义后退**：楼栋视图 → X1 → 返回校区视图（不 pop route）
5. **`webview_notice_page` WebView 优先**：详情页浏览到第二层 → X1 → WebView 自身回退；继续到顶 → route 被 pop
6. **Fragment 子导航**：在某个使用 `popupOrNavigate` 的大屏 dialog 内通过子链接打开子页 → X1 → 子页被 pop；再按一次 → dialog 关闭
7. **移动端负向用例**：`flutter run -d android` / `-d ios`，确认侧键物理不存在时无任何行为变化