### PR TITLE
refactor(auth): 统一重构登录服务架构，接入 AuthSession 自动重试框架

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,1 +1,2 @@
 settings.local.json
+plans/

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -9,6 +9,7 @@ import 'package:bugaoshan/pages/wizard/eula_gate_page.dart';
 import 'package:bugaoshan/pages/wizard/wizard_page.dart';
 import 'package:bugaoshan/providers/app_config_provider.dart';
 import 'package:bugaoshan/services/background_cache_service.dart';
+import 'package:bugaoshan/widgets/common/session_expired_listener.dart';
 import 'package:bugaoshan/widgets/eula_content.dart';
 import 'package:bugaoshan/widgets/route/router_utils.dart';
 import 'package:system_theme/system_theme.dart';
@@ -76,6 +77,8 @@ class _MyAppState extends State<MyApp> {
         theme: _buildTheme(Brightness.light),
         darkTheme: _buildTheme(Brightness.dark),
         themeMode: ThemeMode.system,
+        builder: (context, child) =>
+            SessionExpiredListener(child: child ?? const SizedBox()),
         home: ValueListenableBuilder<int>(
           valueListenable: _appConfig.acceptedEulaVersion,
           builder: (_, eulaVersion, _) {

--- a/lib/services/auth/auth_manager.dart
+++ b/lib/services/auth/auth_manager.dart
@@ -55,6 +55,14 @@ class AuthManager {
     ccyl.removeListener(listener);
   }
 
+  /// 注册全局 session 过期回调。任一 session 刷新失败时触发。
+  void onSessionExpired(void Function() callback) {
+    scu.onSessionExpired = callback;
+    payApp.onSessionExpired = callback;
+    fitness.onSessionExpired = callback;
+    ccyl.onSessionExpired = callback;
+  }
+
   /// 初始化所有 session（从持久化存储恢复 token 等）。
   Future<void> init() async {
     await Future.wait([scu.init(), ccyl.init()]);

--- a/lib/services/auth/auth_session.dart
+++ b/lib/services/auth/auth_session.dart
@@ -21,6 +21,10 @@ abstract class AuthSession<T extends http.Client> extends ChangeNotifier {
   /// 服务名称（用于日志 / 调试）
   String get serviceName;
 
+  /// 当 session 过期且自动刷新失败时调用。
+  /// 用于在 UI 层显示提示（如 snackbar），由 [AuthManager] 统一注册。
+  void Function()? onSessionExpired;
+
   @protected
   set state(AuthState value) {
     if (_state != value) {
@@ -92,6 +96,7 @@ abstract class AuthSession<T extends http.Client> extends ChangeNotifier {
       final refreshed = await _synchronizedRefresh();
       if (!refreshed) {
         state = AuthState.error;
+        onSessionExpired?.call();
         rethrow;
       }
 
@@ -111,6 +116,7 @@ abstract class AuthSession<T extends http.Client> extends ChangeNotifier {
 
       if (!refreshed) {
         state = AuthState.error;
+        onSessionExpired?.call();
         rethrow;
       }
 

--- a/lib/services/balance_query_service.dart
+++ b/lib/services/balance_query_service.dart
@@ -1,8 +1,5 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
-import 'package:bugaoshan/injection/injector.dart';
-import 'package:bugaoshan/providers/scu_auth_provider.dart';
-import 'package:bugaoshan/services/scu_auth_service.dart';
 import 'package:bugaoshan/utils/constants.dart';
 import 'package:bugaoshan/utils/json_utils.dart';
 
@@ -16,31 +13,6 @@ class BalanceQueryService {
     'Referer': _base,
     'User-Agent': kDefaultUserAgent,
   };
-
-  Future<http.Client> getAuthenticatedClient() async {
-    final auth = getIt<ScuAuthProvider>();
-    if (auth.accessToken == null) {
-      throw BalanceQueryAuthException('notLoggedIn');
-    }
-
-    // 检查 token 是否已过期
-    if (auth.isExpired) {
-      throw ScuLoginException('登录已过期，请重新登录', sessionExpired: true);
-    }
-
-    final client = await auth.service.bindSession();
-
-    await client.followRedirects(
-      Uri.parse('$_base/oauth/airWarrant'),
-      headers: {
-        'Accept': 'text/html,application/xhtml+xml,*/*',
-        'User-Agent': _headers['User-Agent']!,
-        'Authorization': 'Bearer ${auth.accessToken}',
-      },
-    );
-
-    return client;
-  }
 
   Future<List<CampusItem>> getCampus(http.Client client) async {
     final resp = await client.post(

--- a/lib/widgets/common/session_expired_listener.dart
+++ b/lib/widgets/common/session_expired_listener.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:bugaoshan/injection/injector.dart';
+import 'package:bugaoshan/l10n/app_localizations.dart';
+import 'package:bugaoshan/pages/auth/scu_login_page.dart';
+import 'package:bugaoshan/services/auth/auth_manager.dart';
+import 'package:bugaoshan/widgets/route/router_utils.dart';
+
+/// 全局 session 过期监听器。
+///
+/// 包裹在 [MaterialApp] 内层，监听所有 [AuthSession] 的刷新失败事件，
+/// 统一显示带「前往登录」action 的 [SnackBar]。
+class SessionExpiredListener extends StatefulWidget {
+  final Widget child;
+  const SessionExpiredListener({super.key, required this.child});
+
+  @override
+  State<SessionExpiredListener> createState() => _SessionExpiredListenerState();
+}
+
+class _SessionExpiredListenerState extends State<SessionExpiredListener> {
+  bool _handling = false;
+
+  @override
+  void initState() {
+    super.initState();
+    getIt<AuthManager>().onSessionExpired(_onSessionExpired);
+  }
+
+  void _onSessionExpired() {
+    if (_handling) return;
+    _handling = true;
+
+    final context = logicRootContext;
+    if (!context.mounted) return;
+    final l10n = AppLocalizations.of(context)!;
+
+    ScaffoldMessenger.of(context)
+      ..clearSnackBars()
+      ..showSnackBar(
+        SnackBar(
+          content: Text(l10n.sessionExpired),
+          action: SnackBarAction(
+            label: l10n.goToLogin,
+            onPressed: () async {
+              ScaffoldMessenger.of(context).hideCurrentSnackBar();
+              await Navigator.of(context).push<bool>(
+                MaterialPageRoute(builder: (_) => const ScuLoginPage()),
+              );
+              // 登录成功后 ScuLoginPage pop(true)，自动回到当前页
+            },
+          ),
+        ),
+      );
+
+    // 冷却期 5s，防止短时间内多个 session 同时失败重复弹出
+    Future.delayed(const Duration(seconds: 5), () => _handling = false);
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}


### PR DESCRIPTION
@## 变更概述

将散落在各 provider/service 里的 token/session 管理收敛到统一的 `AuthSession` 抽象基类，4 个后端服务（SCU 统一认证、电费、体测、第二课堂）各自实现一份。

## Commits
### 死代码清理 & 全局 snackbar
- **8ccefdf** — 删除 `BalanceQueryService.getAuthenticatedClient()` 死代码；新增 `SessionExpiredListener` 全局监听 session 过期并弹出带「前往登录」action 的 SnackBar

## 关键设计

- **`AuthSession.request()`** — 统一请求包装，自动处理 `ScuLoginException(sessionExpired)` → `_synchronizedRefresh()`（并发互斥）→ 重试一次
- **`identical(client, _cachedClient)`** — 用对象身份判断 SCU refresh 后 client 是否已更换，强制子 session 重新走 OAuth/SSO
- **`onSessionExpired` 回调** — 在 `request()` 刷新失败时触发，由 `SessionExpiredListener` 接管弹出 snackbar
- **5s 防抖** — 多 session 并发失败时只弹一次 snackbar

## 后续 PR

- 迁移 `PlanCompletionProvider` / `TrainProgramProvider` / `ProfileLabelsProvider` / `GradesProvider` 到 `AuthManager.scu.request()`
- 评估是否废弃 `SessionExpiryHandler`（当所有 provider 迁移完成后）
@