### PR TITLE
feat: 节假日与节气标签显示

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -673,5 +673,36 @@
             "month": {"type": "int"},
             "day": {"type": "int"}
         }
+    },
+    "holidayLabel": "Hol",
+    "@holidayLabel": {
+        "description": "Short label for statutory holiday displayed in course grid date header"
+    },
+    "festivalLabel": "Fes",
+    "@festivalLabel": {
+        "description": "Short label for festival displayed in course grid date header"
+    },
+    "solarTermLabel": "Term",
+    "@solarTermLabel": {
+        "description": "Short label for solar term displayed in course grid date header"
+    },
+    "holidayTypeLabel": "Holiday",
+    "@holidayTypeLabel": {
+        "description": "Label for statutory holiday type shown in special day detail sheet"
+    },
+    "festivalTypeLabel": "Festival",
+    "@festivalTypeLabel": {
+        "description": "Label for festival type shown in special day detail sheet"
+    },
+    "solarTermTypeLabel": "Solar Term",
+    "@solarTermTypeLabel": {
+        "description": "Label for solar term type shown in special day detail sheet"
+    },
+    "holidayTotalDays": "{days}-day holiday",
+    "@holidayTotalDays": {
+        "description": "Shows total holiday days, e.g. '3-day holiday'",
+        "placeholders": {
+            "days": {"type": "int"}
+        }
     }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -666,5 +666,12 @@
     "downloadedAttachmentsDesc": "Manage downloaded notice attachments",
     "jwcTabLabel": "Academic",
     "xgbTabLabel": "Party Affairs",
-    "tuanweiTabLabel": "Youth SCU"
+    "tuanweiTabLabel": "Youth SCU",
+    "dateMonthDay": "{month}/{day}",
+    "@dateMonthDay": {
+        "placeholders": {
+            "month": {"type": "int"},
+            "day": {"type": "int"}
+        }
+    }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -165,7 +165,7 @@
     "sunday":"Sun",
     "currentWeek":"Week {week}",
     "thisWeek":"This week",
-    "weekRange":"Week {start} - {end}",
+    "weekRange":"Week {start}-{end}",
     "@weekRange": {
         "placeholders": {
             "start": {"type": "int"},
@@ -177,6 +177,14 @@
     "oddWeek":"Odd Week",
     "evenWeek":"Even Week",
     "section":"Sec",
+    "sectionRange": "Sec {start}-{end}",
+    "@sectionRange": {
+        "description": "Section range display, e.g. 'Sec 1-2'",
+        "placeholders": {
+            "start": {"type": "int"},
+            "end": {"type": "int"}
+        }
+    },
     "sectionCount":"Sections per Day",
     "timeSlot":"Time Slot",
     "startTime":"Start Time",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3582,6 +3582,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Youth SCU'**
   String get tuanweiTabLabel;
+
+  /// No description provided for @dateMonthDay.
+  ///
+  /// In en, this message translates to:
+  /// **'{month}/{day}'**
+  String dateMonthDay(int month, int day);
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -940,7 +940,7 @@ abstract class AppLocalizations {
   /// No description provided for @weekRange.
   ///
   /// In en, this message translates to:
-  /// **'Week {start} - {end}'**
+  /// **'Week {start}-{end}'**
   String weekRange(int start, int end);
 
   /// No description provided for @weekType.
@@ -972,6 +972,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Sec'**
   String get section;
+
+  /// Section range display, e.g. 'Sec 1-2'
+  ///
+  /// In en, this message translates to:
+  /// **'Sec {start}-{end}'**
+  String sectionRange(int start, int end);
 
   /// No description provided for @sectionCount.
   ///

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3588,6 +3588,48 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'{month}/{day}'**
   String dateMonthDay(int month, int day);
+
+  /// Short label for statutory holiday displayed in course grid date header
+  ///
+  /// In en, this message translates to:
+  /// **'Hol'**
+  String get holidayLabel;
+
+  /// Short label for festival displayed in course grid date header
+  ///
+  /// In en, this message translates to:
+  /// **'Fes'**
+  String get festivalLabel;
+
+  /// Short label for solar term displayed in course grid date header
+  ///
+  /// In en, this message translates to:
+  /// **'Term'**
+  String get solarTermLabel;
+
+  /// Label for statutory holiday type shown in special day detail sheet
+  ///
+  /// In en, this message translates to:
+  /// **'Holiday'**
+  String get holidayTypeLabel;
+
+  /// Label for festival type shown in special day detail sheet
+  ///
+  /// In en, this message translates to:
+  /// **'Festival'**
+  String get festivalTypeLabel;
+
+  /// Label for solar term type shown in special day detail sheet
+  ///
+  /// In en, this message translates to:
+  /// **'Solar Term'**
+  String get solarTermTypeLabel;
+
+  /// Shows total holiday days, e.g. '3-day holiday'
+  ///
+  /// In en, this message translates to:
+  /// **'{days}-day holiday'**
+  String holidayTotalDays(int days);
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -453,7 +453,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String weekRange(int start, int end) {
-    return 'Week $start - $end';
+    return 'Week $start-$end';
   }
 
   @override
@@ -470,6 +470,11 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get section => 'Sec';
+
+  @override
+  String sectionRange(int start, int end) {
+    return 'Sec $start-$end';
+  }
 
   @override
   String get sectionCount => 'Sections per Day';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1861,4 +1861,9 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get tuanweiTabLabel => 'Youth SCU';
+
+  @override
+  String dateMonthDay(int month, int day) {
+    return '$month/$day';
+  }
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1866,4 +1866,27 @@ class AppLocalizationsEn extends AppLocalizations {
   String dateMonthDay(int month, int day) {
     return '$month/$day';
   }
+
+  @override
+  String get holidayLabel => 'Hol';
+
+  @override
+  String get festivalLabel => 'Fes';
+
+  @override
+  String get solarTermLabel => 'Term';
+
+  @override
+  String get holidayTypeLabel => 'Holiday';
+
+  @override
+  String get festivalTypeLabel => 'Festival';
+
+  @override
+  String get solarTermTypeLabel => 'Solar Term';
+
+  @override
+  String holidayTotalDays(int days) {
+    return '$days-day holiday';
+  }
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -441,7 +441,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String weekRange(int start, int end) {
-    return '第 $start - $end 周';
+    return '$start-$end 周';
   }
 
   @override
@@ -458,6 +458,11 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get section => '节';
+
+  @override
+  String sectionRange(int start, int end) {
+    return '第$start-$end节';
+  }
 
   @override
   String get sectionCount => '每天节数';

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1813,6 +1813,29 @@ class AppLocalizationsZh extends AppLocalizations {
   String dateMonthDay(int month, int day) {
     return '$month月$day日';
   }
+
+  @override
+  String get holidayLabel => '假';
+
+  @override
+  String get festivalLabel => '节';
+
+  @override
+  String get solarTermLabel => '气';
+
+  @override
+  String get holidayTypeLabel => '节假日';
+
+  @override
+  String get festivalTypeLabel => '节日';
+
+  @override
+  String get solarTermTypeLabel => '节气';
+
+  @override
+  String holidayTotalDays(int days) {
+    return '共$days天假';
+  }
 }
 
 /// The translations for Chinese, as used in China, using the Han script (`zh_Hans_CN`).

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1808,6 +1808,11 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get tuanweiTabLabel => '青春川大';
+
+  @override
+  String dateMonthDay(int month, int day) {
+    return '$month月$day日';
+  }
 }
 
 /// The translations for Chinese, as used in China, using the Han script (`zh_Hans_CN`).

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -671,5 +671,36 @@
             "month": {"type": "int"},
             "day": {"type": "int"}
         }
+    },
+    "holidayLabel": "假",
+    "@holidayLabel": {
+        "description": "Short label for statutory holiday displayed in course grid date header"
+    },
+    "festivalLabel": "节",
+    "@festivalLabel": {
+        "description": "Short label for festival displayed in course grid date header"
+    },
+    "solarTermLabel": "气",
+    "@solarTermLabel": {
+        "description": "Short label for solar term displayed in course grid date header"
+    },
+    "holidayTypeLabel": "节假日",
+    "@holidayTypeLabel": {
+        "description": "Label for statutory holiday type shown in special day detail sheet"
+    },
+    "festivalTypeLabel": "节日",
+    "@festivalTypeLabel": {
+        "description": "Label for festival type shown in special day detail sheet"
+    },
+    "solarTermTypeLabel": "节气",
+    "@solarTermTypeLabel": {
+        "description": "Label for solar term type shown in special day detail sheet"
+    },
+    "holidayTotalDays": "共{days}天假",
+    "@holidayTotalDays": {
+        "description": "Shows total holiday days, e.g. '共3天假'",
+        "placeholders": {
+            "days": {"type": "int"}
+        }
     }
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -164,7 +164,7 @@
     "sunday":"周日",
     "currentWeek":"第 {week} 周",
     "thisWeek":"本周",
-    "weekRange":"第 {start} - {end} 周",
+    "weekRange":"{start}-{end} 周",
     "@weekRange": {
         "placeholders": {
             "start": {"type": "int"},
@@ -176,6 +176,14 @@
     "oddWeek":"单周",
     "evenWeek":"双周",
     "section":"节",
+    "sectionRange": "第{start}-{end}节",
+    "@sectionRange": {
+        "description": "Section range display, e.g. '第1-2节'",
+        "placeholders": {
+            "start": {"type": "int"},
+            "end": {"type": "int"}
+        }
+    },
     "sectionCount":"每天节数",
     "timeSlot":"时间段",
     "startTime":"开始时间",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -664,5 +664,12 @@
     "downloadedAttachmentsDesc": "管理已下载的通知附件",
     "jwcTabLabel": "教务处",
     "xgbTabLabel": "党委学工部",
-    "tuanweiTabLabel": "青春川大"
+    "tuanweiTabLabel": "青春川大",
+    "dateMonthDay": "{month}月{day}日",
+    "@dateMonthDay": {
+        "placeholders": {
+            "month": {"type": "int"},
+            "day": {"type": "int"}
+        }
+    }
 }

--- a/lib/pages/course/course_page.dart
+++ b/lib/pages/course/course_page.dart
@@ -14,6 +14,8 @@ import 'package:bugaoshan/widgets/course/course_grid.dart';
 import 'package:bugaoshan/widgets/dialog/dialog.dart';
 import 'package:bugaoshan/widgets/route/router_utils.dart';
 import 'package:bugaoshan/utils/export_schedule_utils.dart';
+import 'package:bugaoshan/utils/holiday_utils.dart';
+import 'package:bugaoshan/widgets/course/special_day_sheet.dart';
 
 part 'course_page_swipe_page_view.dart';
 part 'course_page_top_bar.dart';
@@ -190,6 +192,7 @@ class _CoursePageState extends State<CoursePage> with WidgetsBindingObserver {
           onCourseTap: _onCourseTap,
           onCourseLongPress: _onCourseLongPress,
           onEmptyTap: _onEmptyTap,
+          onSpecialDayTap: _onSpecialDayTap,
         );
       },
     );

--- a/lib/pages/course/course_page_actions.dart
+++ b/lib/pages/course/course_page_actions.dart
@@ -120,4 +120,8 @@ extension _CoursePageActions on _CoursePageState {
       CourseEditPage(prefillDayOfWeek: dayOfWeek, prefillSection: section),
     );
   }
+
+  void _onSpecialDayTap(DateTime date, SpecialDayInfo info) {
+    showSpecialDaySheet(context, date, info);
+  }
 }

--- a/lib/utils/holiday_utils.dart
+++ b/lib/utils/holiday_utils.dart
@@ -1,0 +1,161 @@
+import 'package:tyme/tyme.dart';
+
+/// 特殊日类型
+enum SpecialDayType { ordinary, festival, holiday, solarTerm }
+
+/// 特殊日信息
+class SpecialDayInfo {
+  final SpecialDayType type;
+  final String? name;
+  final String? subtitle;
+
+  SpecialDayInfo({required this.type, this.name, this.subtitle});
+}
+
+/// 中国法定节假日检测工具
+///
+/// 基于 [tyme](https://pub.dev/packages/tyme) 库计算：
+/// - 法定假日数据来自国务院官方安排（自 2001-12-29 起）
+/// - 节气采用寿星天文算法精确计算
+/// - 公历节日和农历传统节日依据国家标准
+class HolidayUtils {
+  HolidayUtils._();
+
+  /// 缓存 {year: {holidayName: totalDays}}
+  static final Map<int, Map<String, int>> _totalDaysCache = {};
+
+  /// 获取 [date] 对应的法定节假日名称，如 '国庆节'
+  /// 调休上班日返回 null
+  static String? getHolidayName(DateTime date) {
+    try {
+      final legalHoliday = SolarDay(
+        date.year,
+        date.month,
+        date.day,
+      ).getLegalHoliday();
+      if (legalHoliday != null && !legalHoliday.isWork()) {
+        return legalHoliday.getName();
+      }
+    } catch (_) {}
+    return null;
+  }
+
+  /// 判断 [date] 是否为法定节假日（放假）
+  static bool isStatutoryHoliday(DateTime date) {
+    return getHolidayName(date) != null;
+  }
+
+  /// 获取 [holidayName] 在 [year] 的总放假天数
+  static int getHolidayTotalDays(String holidayName, int year) {
+    return _totalDaysCache
+        .putIfAbsent(year, () => {})
+        .putIfAbsent(
+          holidayName,
+          () => _computeHolidayTotalDays(holidayName, year),
+        );
+  }
+
+  static int _computeHolidayTotalDays(String holidayName, int year) {
+    int count = 0;
+    for (var month = 1; month <= 12; month++) {
+      final daysInMonth = DateTime(year, month + 1, 0).day;
+      for (var day = 1; day <= daysInMonth; day++) {
+        try {
+          final legalHoliday = SolarDay(year, month, day).getLegalHoliday();
+          if (legalHoliday != null &&
+              !legalHoliday.isWork() &&
+              legalHoliday.getName() == holidayName) {
+            count++;
+          }
+        } catch (_) {}
+      }
+    }
+    return count;
+  }
+
+  /// 获取 [date] 对应的节日名称，如 '元宵节'、'教师节'
+  /// 已归入法定假日的春节、清明节不再重复
+  static String? getFestivalName(DateTime date) {
+    try {
+      final solarDay = SolarDay(date.year, date.month, date.day);
+      // 公历现代节日
+      final sf = solarDay.getFestival();
+      if (sf != null) return sf.getName();
+      // 农历传统节日（跳过已归入法定假日的春节、清明）
+      final lf = solarDay.getLunarDay().getFestival();
+      if (lf != null) {
+        final name = lf.getName();
+        if (name != '春节' && name != '清明节') return name;
+      }
+    } catch (_) {}
+    return null;
+  }
+
+  /// 判断 [date] 是否为标记节日
+  static bool isFestival(DateTime date) => getFestivalName(date) != null;
+
+  /// 获取 [date] 对应的节气名称，如 '立春'
+  /// 仅当天返回名称（节气开始日），非持续期间
+  static String? getSolarTermName(DateTime date) {
+    try {
+      final termDay = SolarDay(date.year, date.month, date.day).getTermDay();
+      if (termDay.dayIndex == 0) {
+        return termDay.getSolarTerm().getName();
+      }
+    } catch (_) {}
+    return null;
+  }
+
+  /// 判断 [date] 是否为节气
+  static bool isSolarTerm(DateTime date) => getSolarTermName(date) != null;
+
+  /// 获取 [date] 对应的特殊日信息（含类型、名称、备注等）
+  ///
+  /// 优先级：假 > 节 > 气 > 普通日
+  static SpecialDayInfo getSpecialDay(DateTime date) {
+    try {
+      final solarDay = SolarDay(date.year, date.month, date.day);
+
+      // 1. 法定假日（放假）
+      final legalHoliday = solarDay.getLegalHoliday();
+      if (legalHoliday != null && !legalHoliday.isWork()) {
+        final totalDays = getHolidayTotalDays(
+          legalHoliday.getName(),
+          date.year,
+        );
+        return SpecialDayInfo(
+          type: SpecialDayType.holiday,
+          name: legalHoliday.getName(),
+          subtitle: '共$totalDays天假',
+        );
+      }
+
+      // 2. 节日（公历 + 农历，跳过春节清明）
+      final sf = solarDay.getFestival();
+      if (sf != null) {
+        return SpecialDayInfo(
+          type: SpecialDayType.festival,
+          name: sf.getName(),
+        );
+      }
+      final lf = solarDay.getLunarDay().getFestival();
+      if (lf != null) {
+        final name = lf.getName();
+        if (name != '春节' && name != '清明节') {
+          return SpecialDayInfo(type: SpecialDayType.festival, name: name);
+        }
+      }
+
+      // 3. 节气（仅当天）
+      final termDay = solarDay.getTermDay();
+      if (termDay.dayIndex == 0) {
+        return SpecialDayInfo(
+          type: SpecialDayType.solarTerm,
+          name: termDay.getSolarTerm().getName(),
+        );
+      }
+    } catch (_) {}
+
+    return SpecialDayInfo(type: SpecialDayType.ordinary);
+  }
+}

--- a/lib/utils/holiday_utils.dart
+++ b/lib/utils/holiday_utils.dart
@@ -46,28 +46,59 @@ class HolidayUtils {
   }
 
   /// 获取 [holidayName] 在 [year] 的总放假天数
-  static int getHolidayTotalDays(String holidayName, int year) {
+  ///
+  /// 若提供 [near] 日期，则仅在该日期前后 30 天内搜索，避免遍历全年。
+  static int getHolidayTotalDays(
+    String holidayName,
+    int year, {
+    DateTime? near,
+  }) {
     return _totalDaysCache
         .putIfAbsent(year, () => {})
         .putIfAbsent(
           holidayName,
-          () => _computeHolidayTotalDays(holidayName, year),
+          () => _computeHolidayTotalDays(holidayName, year, near: near),
         );
   }
 
-  static int _computeHolidayTotalDays(String holidayName, int year) {
+  static int _computeHolidayTotalDays(
+    String holidayName,
+    int year, {
+    DateTime? near,
+  }) {
     int count = 0;
-    for (var month = 1; month <= 12; month++) {
-      final daysInMonth = DateTime(year, month + 1, 0).day;
-      for (var day = 1; day <= daysInMonth; day++) {
+    if (near != null) {
+      // 在 near 前后 30 天内搜索（覆盖最长假期）
+      final start = near.subtract(const Duration(days: 30));
+      final end = near.add(const Duration(days: 30));
+      for (var d = start; !d.isAfter(end); d = d.add(const Duration(days: 1))) {
+        if (d.year != year) continue;
         try {
-          final legalHoliday = SolarDay(year, month, day).getLegalHoliday();
+          final legalHoliday = SolarDay(
+            d.year,
+            d.month,
+            d.day,
+          ).getLegalHoliday();
           if (legalHoliday != null &&
               !legalHoliday.isWork() &&
               legalHoliday.getName() == holidayName) {
             count++;
           }
         } catch (_) {}
+      }
+    } else {
+      for (var month = 1; month <= 12; month++) {
+        final daysInMonth = DateTime(year, month + 1, 0).day;
+        for (var day = 1; day <= daysInMonth; day++) {
+          try {
+            final legalHoliday = SolarDay(year, month, day).getLegalHoliday();
+            if (legalHoliday != null &&
+                !legalHoliday.isWork() &&
+                legalHoliday.getName() == holidayName) {
+              count++;
+            }
+          } catch (_) {}
+        }
       }
     }
     return count;
@@ -122,6 +153,7 @@ class HolidayUtils {
         final totalDays = getHolidayTotalDays(
           legalHoliday.getName(),
           date.year,
+          near: date,
         );
         return SpecialDayInfo(
           type: SpecialDayType.holiday,

--- a/lib/utils/holiday_utils.dart
+++ b/lib/utils/holiday_utils.dart
@@ -7,9 +7,9 @@ enum SpecialDayType { ordinary, festival, holiday, solarTerm }
 class SpecialDayInfo {
   final SpecialDayType type;
   final String? name;
-  final String? subtitle;
+  final int? holidayTotalDays;
 
-  SpecialDayInfo({required this.type, this.name, this.subtitle});
+  SpecialDayInfo({required this.type, this.name, this.holidayTotalDays});
 }
 
 /// 兜底用固定日期节假日映射。
@@ -174,7 +174,7 @@ class HolidayUtils {
           return SpecialDayInfo(
             type: SpecialDayType.holiday,
             name: legalHoliday.getName(),
-            subtitle: '共$totalDays天假',
+            holidayTotalDays: totalDays,
           );
         }
         // tyme 标记为上班 → 不放假，不继续降级

--- a/lib/utils/holiday_utils.dart
+++ b/lib/utils/holiday_utils.dart
@@ -12,6 +12,16 @@ class SpecialDayInfo {
   SpecialDayInfo({required this.type, this.name, this.subtitle});
 }
 
+/// 兜底用固定日期节假日映射。
+///
+/// 当 tyme 无某年数据时，这些日期必定放假，可直接做降级显示。
+/// 其余依赖农历的法定假日（春节、清明、端午、中秋）天数不定，不在此列。
+const Map<int, Map<int, String>> _kFixedHolidays = {
+  1: {1: '元旦'},
+  5: {1: '劳动节'},
+  10: {1: '国庆节'},
+};
+
 /// 中国法定节假日检测工具
 ///
 /// 基于 [tyme](https://pub.dev/packages/tyme) 库计算：
@@ -24,6 +34,11 @@ class HolidayUtils {
   /// 缓存 {year: {holidayName: totalDays}}
   static final Map<int, Map<String, int>> _totalDaysCache = {};
 
+  /// tyme 无数据时降级：返回固定日期假日的名称
+  static String? _getFixedHolidayFallback(DateTime date) {
+    return _kFixedHolidays[date.month]?[date.day];
+  }
+
   /// 获取 [date] 对应的法定节假日名称，如 '国庆节'
   /// 调休上班日返回 null
   static String? getHolidayName(DateTime date) {
@@ -33,11 +48,12 @@ class HolidayUtils {
         date.month,
         date.day,
       ).getLegalHoliday();
-      if (legalHoliday != null && !legalHoliday.isWork()) {
-        return legalHoliday.getName();
+      if (legalHoliday != null) {
+        return legalHoliday.isWork() ? null : legalHoliday.getName();
       }
     } catch (_) {}
-    return null;
+    // tyme 无此日数据 → 固定日期放假兜底
+    return _getFixedHolidayFallback(date);
   }
 
   /// 判断 [date] 是否为法定节假日（放假）
@@ -144,25 +160,44 @@ class HolidayUtils {
   ///
   /// 优先级：假 > 节 > 气 > 普通日
   static SpecialDayInfo getSpecialDay(DateTime date) {
+    // 1. 法定假日（tyme）
+    try {
+      final solarDay = SolarDay(date.year, date.month, date.day);
+      final legalHoliday = solarDay.getLegalHoliday();
+      if (legalHoliday != null) {
+        if (!legalHoliday.isWork()) {
+          final totalDays = getHolidayTotalDays(
+            legalHoliday.getName(),
+            date.year,
+            near: date,
+          );
+          return SpecialDayInfo(
+            type: SpecialDayType.holiday,
+            name: legalHoliday.getName(),
+            subtitle: '共$totalDays天假',
+          );
+        }
+        // tyme 标记为上班 → 不放假，不继续降级
+      } else {
+        // 1b. 兜底：固定日期法定假日（tyme 无数据）
+        final fallback = _getFixedHolidayFallback(date);
+        if (fallback != null) {
+          return SpecialDayInfo(type: SpecialDayType.holiday, name: fallback);
+        }
+      }
+    } catch (_) {
+      // tyme 异常 → 尝试固定日期兜底
+      final fallback = _getFixedHolidayFallback(date);
+      if (fallback != null) {
+        return SpecialDayInfo(type: SpecialDayType.holiday, name: fallback);
+      }
+    }
+
+    // 2. 节日 + 节气
     try {
       final solarDay = SolarDay(date.year, date.month, date.day);
 
-      // 1. 法定假日（放假）
-      final legalHoliday = solarDay.getLegalHoliday();
-      if (legalHoliday != null && !legalHoliday.isWork()) {
-        final totalDays = getHolidayTotalDays(
-          legalHoliday.getName(),
-          date.year,
-          near: date,
-        );
-        return SpecialDayInfo(
-          type: SpecialDayType.holiday,
-          name: legalHoliday.getName(),
-          subtitle: '共$totalDays天假',
-        );
-      }
-
-      // 2. 节日（公历 + 农历，跳过春节清明）
+      // 2a. 节日（公历 + 农历，跳过春节清明）
       final sf = solarDay.getFestival();
       if (sf != null) {
         return SpecialDayInfo(
@@ -178,7 +213,7 @@ class HolidayUtils {
         }
       }
 
-      // 3. 节气（仅当天）
+      // 2b. 节气（仅当天）
       final termDay = solarDay.getTermDay();
       if (termDay.dayIndex == 0) {
         return SpecialDayInfo(

--- a/lib/utils/holiday_utils.dart
+++ b/lib/utils/holiday_utils.dart
@@ -83,24 +83,49 @@ class HolidayUtils {
     DateTime? near,
   }) {
     int count = 0;
+
     if (near != null) {
-      // 在 near 前后 30 天内搜索（覆盖最长假期）
-      final start = near.subtract(const Duration(days: 30));
-      final end = near.add(const Duration(days: 30));
-      for (var d = start; !d.isAfter(end); d = d.add(const Duration(days: 1))) {
-        if (d.year != year) continue;
+      // date 本身必定是节假日，向前往后遍历直到非节假日或不同假日名称
+      count = 1;
+      // 向前遍历
+      var d = near.subtract(const Duration(days: 1));
+      while (d.year == year) {
         try {
           final legalHoliday = SolarDay(
             d.year,
             d.month,
             d.day,
           ).getLegalHoliday();
-          if (legalHoliday != null &&
-              !legalHoliday.isWork() &&
-              legalHoliday.getName() == holidayName) {
-            count++;
+          if (legalHoliday == null ||
+              legalHoliday.isWork() ||
+              legalHoliday.getName() != holidayName) {
+            break;
           }
-        } catch (_) {}
+          count++;
+        } catch (_) {
+          break;
+        }
+        d = d.subtract(const Duration(days: 1));
+      }
+      // 向后遍历
+      d = near.add(const Duration(days: 1));
+      while (d.year == year) {
+        try {
+          final legalHoliday = SolarDay(
+            d.year,
+            d.month,
+            d.day,
+          ).getLegalHoliday();
+          if (legalHoliday == null ||
+              legalHoliday.isWork() ||
+              legalHoliday.getName() != holidayName) {
+            break;
+          }
+          count++;
+        } catch (_) {
+          break;
+        }
+        d = d.add(const Duration(days: 1));
       }
     } else {
       for (var month = 1; month <= 12; month++) {

--- a/lib/widgets/course/course_card.dart
+++ b/lib/widgets/course/course_card.dart
@@ -48,8 +48,8 @@ class CourseCard extends StatelessWidget {
           if (config.showTeacherName && course.teacher.isNotEmpty)
             (text: course.teacher, preferredMaxLines: 1),
           (
-            text: '${l10n.week} ${course.startWeek}-${course.endWeek}',
-            preferredMaxLines: 1,
+            text: l10n.weekRange(course.startWeek, course.endWeek),
+            preferredMaxLines: 2,
           ),
         ];
 
@@ -61,8 +61,8 @@ class CourseCard extends StatelessWidget {
               final height = constraints.maxHeight;
               final detailLineBudget = switch (height) {
                 < 56 => 0,
-                < 100 => 2,
-                _ => 4,
+                < 100 => 3,
+                _ => 5,
               };
               final visibleDetails = <({String text, int preferredMaxLines})>[];
               var usedDetailLines = 0;
@@ -141,6 +141,7 @@ class CourseCard extends StatelessWidget {
       padding: const EdgeInsets.only(top: 2),
       child: Text(
         text,
+        maxLines: maxLines,
         softWrap: true,
         style: TextStyle(
           fontSize: fontSize,

--- a/lib/widgets/course/course_card.dart
+++ b/lib/widgets/course/course_card.dart
@@ -42,22 +42,13 @@ class CourseCard extends StatelessWidget {
             : Colors.white;
         final fontSize = appConfig.courseCardFontSize.value;
         final smallFontSize = fontSize - 1;
-        final details = <({IconData icon, String text, int preferredMaxLines})>[
+        final details = <({String text, int preferredMaxLines})>[
           if (config.showLocation && course.location.isNotEmpty)
-            (
-              icon: Icons.location_on_outlined,
-              text: course.location,
-              preferredMaxLines: 2,
-            ),
+            (text: course.location, preferredMaxLines: 2),
           if (config.showTeacherName && course.teacher.isNotEmpty)
-            (
-              icon: Icons.person_outline,
-              text: course.teacher,
-              preferredMaxLines: 1,
-            ),
+            (text: course.teacher, preferredMaxLines: 1),
           (
-            icon: Icons.calendar_today_outlined,
-            text: '${course.startWeek}-${course.endWeek}${l10n.week}',
+            text: '${l10n.week} ${course.startWeek}-${course.endWeek}',
             preferredMaxLines: 1,
           ),
         ];
@@ -73,8 +64,7 @@ class CourseCard extends StatelessWidget {
                 < 100 => 2,
                 _ => 4,
               };
-              final visibleDetails =
-                  <({IconData icon, String text, int preferredMaxLines})>[];
+              final visibleDetails = <({String text, int preferredMaxLines})>[];
               var usedDetailLines = 0;
               for (final detail in details) {
                 final nextUsedLines =
@@ -122,7 +112,6 @@ class CourseCard extends StatelessWidget {
                             const SizedBox(height: 2),
                           ...visibleDetails.map(
                             (detail) => _buildIconText(
-                              detail.icon,
                               detail.text,
                               smallFontSize,
                               textColor,
@@ -143,7 +132,6 @@ class CourseCard extends StatelessWidget {
   }
 
   Widget _buildIconText(
-    IconData icon,
     String text,
     double fontSize,
     Color color, {
@@ -153,7 +141,7 @@ class CourseCard extends StatelessWidget {
       padding: const EdgeInsets.only(top: 2),
       child: Text(
         text,
-        maxLines: maxLines,
+        softWrap: true,
         style: TextStyle(
           fontSize: fontSize,
           color: color.withAlpha(230),

--- a/lib/widgets/course/course_detail_sheet.dart
+++ b/lib/widgets/course/course_detail_sheet.dart
@@ -145,7 +145,7 @@ class CourseDetailSheet extends StatelessWidget {
                     icon: Icons.access_time_outlined,
                     iconColor: Colors.orange,
                     text:
-                        '第 ${course.startSection} - ${course.endSection} ${l10n.section}   $timeRange',
+                        '${l10n.sectionRange(course.startSection, course.endSection)}   $timeRange',
                   ),
                   if (course.teacher.isNotEmpty)
                     _InfoItem(

--- a/lib/widgets/course/course_grid.dart
+++ b/lib/widgets/course/course_grid.dart
@@ -3,7 +3,9 @@ import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/models/course.dart';
 import 'package:bugaoshan/providers/app_config_provider.dart';
+import 'package:bugaoshan/utils/holiday_utils.dart';
 import 'package:bugaoshan/widgets/course/course_card.dart';
+import 'package:bugaoshan/widgets/course/special_day_sheet.dart';
 
 List<Course> selectVisibleCoursesForDay(
   List<Course> courses,
@@ -66,6 +68,7 @@ class CourseGrid extends StatefulWidget {
   final void Function(Course course)? onCourseTap;
   final void Function(Course course)? onCourseLongPress;
   final void Function(int dayOfWeek, int section)? onEmptyTap;
+  final void Function(DateTime date, SpecialDayInfo info)? onSpecialDayTap;
 
   const CourseGrid({
     super.key,
@@ -76,6 +79,7 @@ class CourseGrid extends StatefulWidget {
     this.onCourseTap,
     this.onCourseLongPress,
     this.onEmptyTap,
+    this.onSpecialDayTap,
   });
 
   @override
@@ -226,49 +230,82 @@ class _CourseGridState extends State<CourseGrid> {
                   ),
                 );
                 final isToday = date.isAtSameMomentAs(today);
+                final specialDay = HolidayUtils.getSpecialDay(date);
+                final hasSpecialDay =
+                    specialDay.type != SpecialDayType.ordinary;
+
+                Color? labelColor;
+                String? label;
+                if (specialDay.type == SpecialDayType.holiday) {
+                  labelColor = Colors.red;
+                  label = '假';
+                } else if (specialDay.type == SpecialDayType.festival) {
+                  labelColor = Colors.orange;
+                  label = '节';
+                } else if (specialDay.type == SpecialDayType.solarTerm) {
+                  labelColor = Colors.green;
+                  label = '气';
+                }
 
                 return Expanded(
-                  child: Container(
-                    decoration: BoxDecoration(
-                      color: isToday
-                          ? theme.colorScheme.primaryContainer.withAlpha(180)
-                          : null,
-                      border: Border(
-                        right: BorderSide(
-                          color: theme.colorScheme.outlineVariant,
-                          width: 0.5,
+                  child: GestureDetector(
+                    onTap: hasSpecialDay && widget.onSpecialDayTap != null
+                        ? () => widget.onSpecialDayTap!(date, specialDay)
+                        : null,
+                    child: Container(
+                      decoration: BoxDecoration(
+                        color: isToday
+                            ? theme.colorScheme.primaryContainer.withAlpha(180)
+                            : null,
+                        border: Border(
+                          right: BorderSide(
+                            color: theme.colorScheme.outlineVariant,
+                            width: 0.5,
+                          ),
                         ),
                       ),
-                    ),
-                    child: Center(
-                      child: Column(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          Text(
-                            name,
-                            style: TextStyle(
-                              fontSize: 13,
-                              fontWeight: isToday
-                                  ? FontWeight.bold
-                                  : FontWeight.w600,
-                              color: isToday
-                                  ? theme.colorScheme.primary
-                                  : theme.colorScheme.onSurface,
+                      child: Center(
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Text(
+                              name,
+                              style: TextStyle(
+                                fontSize: 13,
+                                fontWeight: isToday
+                                    ? FontWeight.bold
+                                    : FontWeight.w600,
+                                color: isToday
+                                    ? theme.colorScheme.primary
+                                    : theme.colorScheme.onSurface,
+                              ),
                             ),
-                          ),
-                          Text(
-                            '${date.month}-${date.day}',
-                            style: TextStyle(
-                              fontSize: 10,
-                              fontWeight: isToday
-                                  ? FontWeight.bold
-                                  : FontWeight.normal,
-                              color: isToday
-                                  ? theme.colorScheme.primary.withAlpha(200)
-                                  : theme.colorScheme.onSurfaceVariant,
+                            Text(
+                              '${date.month}-${date.day}',
+                              style: TextStyle(
+                                fontSize: 10,
+                                fontWeight: isToday
+                                    ? FontWeight.bold
+                                    : FontWeight.normal,
+                                color: isToday
+                                    ? theme.colorScheme.primary.withAlpha(200)
+                                    : theme.colorScheme.onSurfaceVariant,
+                              ),
                             ),
-                          ),
-                        ],
+                            if (label != null)
+                              Padding(
+                                padding: const EdgeInsets.only(top: 1),
+                                child: Text(
+                                  label,
+                                  style: TextStyle(
+                                    fontSize: 10,
+                                    fontWeight: FontWeight.bold,
+                                    color: labelColor,
+                                  ),
+                                ),
+                              ),
+                          ],
+                        ),
                       ),
                     ),
                   ),

--- a/lib/widgets/course/course_grid.dart
+++ b/lib/widgets/course/course_grid.dart
@@ -138,7 +138,7 @@ class _CourseGridState extends State<CourseGrid> {
       builder: (context, _) {
         return Column(
           children: [
-            _buildHeaderRow(context, dayNames),
+            _buildHeaderRow(context, dayNames, l10n),
             Expanded(
               child: SingleChildScrollView(
                 scrollDirection: Axis.vertical,
@@ -179,7 +179,11 @@ class _CourseGridState extends State<CourseGrid> {
     );
   }
 
-  Widget _buildHeaderRow(BuildContext context, List<String> dayNames) {
+  Widget _buildHeaderRow(
+    BuildContext context,
+    List<String> dayNames,
+    AppLocalizations l10n,
+  ) {
     final theme = Theme.of(context);
     final visibleDays = widget.config.showWeekend
         ? dayNames
@@ -278,7 +282,7 @@ class _CourseGridState extends State<CourseGrid> {
                               mainAxisSize: MainAxisSize.min,
                               children: [
                                 Text(
-                                  '${date.month}-${date.day}',
+                                  l10n.dateMonthDay(date.month, date.day),
                                   style: TextStyle(
                                     fontSize: 10,
                                     fontWeight: isToday
@@ -297,33 +301,27 @@ class _CourseGridState extends State<CourseGrid> {
                                         : theme.colorScheme.onSurfaceVariant,
                                   ),
                                 ),
-                                if (isHoliday)
-                                  const Text(
-                                    ' 假',
-                                    style: TextStyle(
-                                      fontSize: 10,
-                                      fontWeight: FontWeight.bold,
-                                      color: Colors.red,
-                                    ),
+                                if (isHoliday) ...[
+                                  const SizedBox(width: 2),
+                                  _buildLabelBadge(
+                                    l10n.holidayLabel,
+                                    Colors.red,
                                   ),
-                                if (isFestival)
-                                  const Text(
-                                    ' 节',
-                                    style: TextStyle(
-                                      fontSize: 10,
-                                      fontWeight: FontWeight.bold,
-                                      color: Colors.orange,
-                                    ),
+                                ],
+                                if (isFestival) ...[
+                                  const SizedBox(width: 2),
+                                  _buildLabelBadge(
+                                    l10n.festivalLabel,
+                                    Colors.orange,
                                   ),
-                                if (isSolarTerm)
-                                  const Text(
-                                    ' 气',
-                                    style: TextStyle(
-                                      fontSize: 10,
-                                      fontWeight: FontWeight.bold,
-                                      color: Colors.green,
-                                    ),
+                                ],
+                                if (isSolarTerm) ...[
+                                  const SizedBox(width: 2),
+                                  _buildLabelBadge(
+                                    l10n.solarTermLabel,
+                                    Colors.green,
                                   ),
+                                ],
                               ],
                             ),
                           ],
@@ -336,6 +334,24 @@ class _CourseGridState extends State<CourseGrid> {
             ),
           ),
         ],
+      ),
+    );
+  }
+
+  Widget _buildLabelBadge(String label, Color color) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 3, vertical: 1),
+      decoration: BoxDecoration(
+        color: color,
+        borderRadius: BorderRadius.circular(3),
+      ),
+      child: Text(
+        label,
+        style: const TextStyle(
+          fontSize: 9,
+          fontWeight: FontWeight.bold,
+          color: Colors.white,
+        ),
       ),
     );
   }

--- a/lib/widgets/course/course_grid.dart
+++ b/lib/widgets/course/course_grid.dart
@@ -5,7 +5,6 @@ import 'package:bugaoshan/models/course.dart';
 import 'package:bugaoshan/providers/app_config_provider.dart';
 import 'package:bugaoshan/utils/holiday_utils.dart';
 import 'package:bugaoshan/widgets/course/course_card.dart';
-import 'package:bugaoshan/widgets/course/special_day_sheet.dart';
 
 List<Course> selectVisibleCoursesForDay(
   List<Course> courses,
@@ -231,30 +230,25 @@ class _CourseGridState extends State<CourseGrid> {
                 );
                 final isToday = date.isAtSameMomentAs(today);
                 final specialDay = HolidayUtils.getSpecialDay(date);
-                final hasSpecialDay =
-                    specialDay.type != SpecialDayType.ordinary;
-
-                Color? labelColor;
-                String? label;
-                if (specialDay.type == SpecialDayType.holiday) {
-                  labelColor = Colors.red;
-                  label = '假';
-                } else if (specialDay.type == SpecialDayType.festival) {
-                  labelColor = Colors.orange;
-                  label = '节';
-                } else if (specialDay.type == SpecialDayType.solarTerm) {
-                  labelColor = Colors.green;
-                  label = '气';
-                }
+                final isHoliday = specialDay.type == SpecialDayType.holiday;
+                final isFestival = specialDay.type == SpecialDayType.festival;
+                final isSolarTerm = specialDay.type == SpecialDayType.solarTerm;
+                final isSpecial = isHoliday || isFestival || isSolarTerm;
 
                 return Expanded(
                   child: GestureDetector(
-                    onTap: hasSpecialDay && widget.onSpecialDayTap != null
+                    onTap: isSpecial && widget.onSpecialDayTap != null
                         ? () => widget.onSpecialDayTap!(date, specialDay)
                         : null,
                     child: Container(
                       decoration: BoxDecoration(
-                        color: isToday
+                        color: isHoliday
+                            ? Colors.red.withAlpha(15)
+                            : isFestival
+                            ? Colors.orange.withAlpha(15)
+                            : isSolarTerm
+                            ? Colors.green.withAlpha(15)
+                            : isToday
                             ? theme.colorScheme.primaryContainer.withAlpha(180)
                             : null,
                         border: Border(
@@ -280,30 +274,58 @@ class _CourseGridState extends State<CourseGrid> {
                                     : theme.colorScheme.onSurface,
                               ),
                             ),
-                            Text(
-                              '${date.month}-${date.day}',
-                              style: TextStyle(
-                                fontSize: 10,
-                                fontWeight: isToday
-                                    ? FontWeight.bold
-                                    : FontWeight.normal,
-                                color: isToday
-                                    ? theme.colorScheme.primary.withAlpha(200)
-                                    : theme.colorScheme.onSurfaceVariant,
-                              ),
-                            ),
-                            if (label != null)
-                              Padding(
-                                padding: const EdgeInsets.only(top: 1),
-                                child: Text(
-                                  label,
+                            Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Text(
+                                  '${date.month}-${date.day}',
                                   style: TextStyle(
                                     fontSize: 10,
-                                    fontWeight: FontWeight.bold,
-                                    color: labelColor,
+                                    fontWeight: isToday
+                                        ? FontWeight.bold
+                                        : FontWeight.normal,
+                                    color: isHoliday
+                                        ? Colors.red
+                                        : isFestival
+                                        ? Colors.orange
+                                        : isSolarTerm
+                                        ? Colors.green
+                                        : isToday
+                                        ? theme.colorScheme.primary.withAlpha(
+                                            200,
+                                          )
+                                        : theme.colorScheme.onSurfaceVariant,
                                   ),
                                 ),
-                              ),
+                                if (isHoliday)
+                                  const Text(
+                                    ' 假',
+                                    style: TextStyle(
+                                      fontSize: 10,
+                                      fontWeight: FontWeight.bold,
+                                      color: Colors.red,
+                                    ),
+                                  ),
+                                if (isFestival)
+                                  const Text(
+                                    ' 节',
+                                    style: TextStyle(
+                                      fontSize: 10,
+                                      fontWeight: FontWeight.bold,
+                                      color: Colors.orange,
+                                    ),
+                                  ),
+                                if (isSolarTerm)
+                                  const Text(
+                                    ' 气',
+                                    style: TextStyle(
+                                      fontSize: 10,
+                                      fontWeight: FontWeight.bold,
+                                      color: Colors.green,
+                                    ),
+                                  ),
+                              ],
+                            ),
                           ],
                         ),
                       ),

--- a/lib/widgets/course/special_day_sheet.dart
+++ b/lib/widgets/course/special_day_sheet.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:bugaoshan/utils/holiday_utils.dart';
+
+/// 点击课表表头的特殊日（假/节/气）后弹出的信息悬浮窗
+Future<void> showSpecialDaySheet(
+  BuildContext context,
+  DateTime date,
+  SpecialDayInfo info,
+) async {
+  switch (info.type) {
+    case SpecialDayType.holiday:
+      await _showSheet(context, date, info, Colors.red);
+    case SpecialDayType.festival:
+      await _showSheet(context, date, info, Colors.orange);
+    case SpecialDayType.solarTerm:
+      await _showSheet(context, date, info, Colors.green);
+    case SpecialDayType.ordinary:
+      break;
+  }
+}
+
+Future<void> _showSheet(
+  BuildContext context,
+  DateTime date,
+  SpecialDayInfo info,
+  Color color,
+) async {
+  await showModalBottomSheet(
+    context: context,
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+    ),
+    builder: (ctx) => SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 16),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 8),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    info.name ?? '${date.month}月${date.day}日',
+                    style: Theme.of(ctx).textTheme.titleLarge?.copyWith(
+                      fontWeight: FontWeight.bold,
+                      color: color,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  if (info.subtitle != null)
+                    Padding(
+                      padding: const EdgeInsets.only(bottom: 2),
+                      child: Text(
+                        info.subtitle!,
+                        style: TextStyle(
+                          fontSize: 13,
+                          color: Theme.of(ctx).colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ),
+                  Text(
+                    '${date.month}月${date.day}日',
+                    style: TextStyle(
+                      fontSize: 13,
+                      color: Theme.of(ctx).colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const Divider(),
+            const SizedBox(height: 8),
+          ],
+        ),
+      ),
+    ),
+  );
+}

--- a/lib/widgets/course/special_day_sheet.dart
+++ b/lib/widgets/course/special_day_sheet.dart
@@ -26,6 +26,14 @@ Future<void> _showSheet(
   SpecialDayInfo info,
   Color color,
 ) async {
+  final l10n = AppLocalizations.of(context)!;
+  final typeLabel = switch (info.type) {
+    SpecialDayType.holiday => l10n.holidayTypeLabel,
+    SpecialDayType.festival => l10n.festivalTypeLabel,
+    SpecialDayType.solarTerm => l10n.solarTermTypeLabel,
+    _ => '',
+  };
+
   await showModalBottomSheet(
     context: context,
     shape: const RoundedRectangleBorder(
@@ -43,32 +51,50 @@ Future<void> _showSheet(
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
+                  // Type badge
+                  Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 8,
+                      vertical: 2,
+                    ),
+                    decoration: BoxDecoration(
+                      color: color.withAlpha(30),
+                      borderRadius: BorderRadius.circular(4),
+                    ),
+                    child: Text(
+                      typeLabel,
+                      style: TextStyle(
+                        fontSize: 12,
+                        fontWeight: FontWeight.w600,
+                        color: color,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  // Holiday/festival/term name
                   Text(
-                    info.name ??
-                        AppLocalizations.of(
-                          ctx,
-                        )!.dateMonthDay(date.month, date.day),
+                    info.name ?? l10n.dateMonthDay(date.month, date.day),
                     style: Theme.of(ctx).textTheme.titleLarge?.copyWith(
                       fontWeight: FontWeight.bold,
                       color: color,
                     ),
                   ),
                   const SizedBox(height: 4),
-                  if (info.subtitle != null)
+                  // Holiday total days subtitle
+                  if (info.holidayTotalDays != null)
                     Padding(
                       padding: const EdgeInsets.only(bottom: 2),
                       child: Text(
-                        info.subtitle!,
+                        l10n.holidayTotalDays(info.holidayTotalDays!),
                         style: TextStyle(
                           fontSize: 13,
                           color: Theme.of(ctx).colorScheme.onSurfaceVariant,
                         ),
                       ),
                     ),
+                  // Date
                   Text(
-                    AppLocalizations.of(
-                      ctx,
-                    )!.dateMonthDay(date.month, date.day),
+                    l10n.dateMonthDay(date.month, date.day),
                     style: TextStyle(
                       fontSize: 13,
                       color: Theme.of(ctx).colorScheme.onSurfaceVariant,

--- a/lib/widgets/course/special_day_sheet.dart
+++ b/lib/widgets/course/special_day_sheet.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/utils/holiday_utils.dart';
 
 /// 点击课表表头的特殊日（假/节/气）后弹出的信息悬浮窗
@@ -43,7 +44,10 @@ Future<void> _showSheet(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Text(
-                    info.name ?? '${date.month}月${date.day}日',
+                    info.name ??
+                        AppLocalizations.of(
+                          ctx,
+                        )!.dateMonthDay(date.month, date.day),
                     style: Theme.of(ctx).textTheme.titleLarge?.copyWith(
                       fontWeight: FontWeight.bold,
                       color: color,
@@ -62,7 +66,9 @@ Future<void> _showSheet(
                       ),
                     ),
                   Text(
-                    '${date.month}月${date.day}日',
+                    AppLocalizations.of(
+                      ctx,
+                    )!.dateMonthDay(date.month, date.day),
                     style: TextStyle(
                       fontSize: 13,
                       color: Theme.of(ctx).colorScheme.onSurfaceVariant,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1300,6 +1300,14 @@ packages:
       url: "https://pub.flutter-io.cn"
     source: hosted
     version: "0.7.11"
+  tyme:
+    dependency: "direct main"
+    description:
+      name: tyme
+      sha256: a6ef4802b02d67ddb472a1ee78ac39b54b245b268c3c8029687e9ad2fd598efb
+      url: "https://pub.flutter-io.cn"
+    source: hosted
+    version: "1.4.4"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   gal: ^2.3.0
   open_filex: ^4.7.0
   flutter_inappwebview: ^6.2.0-beta.3
+  tyme: ^1.4.4
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
# feat: 节假日与节气标签显示（课表表头）

## PR 描述

### 背景

PR #122 原方案包含完整的调休管理系统（数据库持久化、小组件同步、通知搜索等），经 reviewers（57UU、jeanhua）讨论认为调休功能过度设计，性价比过低。决定**只保留节假日和节气的标签显示及相关功能**，去掉所有调休/设置放假功能。

### 变更内容

**新增文件**

| 文件 | 说明 |
|------|------|
| holiday_utils.dart | 节假日/节气/节日检测工具，基于 `tyme` 库 |
| special_day_sheet.dart | 假/节/气信息浮窗，仅信息展示，无操作按钮 |

**修改文件**

| 文件 | 说明 |
|------|------|
| course_grid.dart | 表头显示标签 + 可点击弹出信息浮窗 |
| course_page.dart | 接入 `onSpecialDayTap` 回调 |
| course_page_actions.dart | 新增 `_onSpecialDayTap` 处理器 |
| `lib/l10n/app_*.arb` | 新增 `dateMonthDay` 国际化键 |
| pubspec.yaml | 添加 `tyme: ^1.4.4` 依赖 |

### 功能说明

课表表头每列（周几/日期）右侧显示特殊日标签：

- 🔴 **假** — 法定节假日（元旦、春节、清明、劳动节、端午、中秋、国庆），tyme 实时数据
- 🟠 **节** — 公历/农历传统节日（元宵节、教师节、重阳节等）
- 🟢 **气** — 二十四节气（立春、雨水、惊蛰等）

表头背景色随类型变化（红/橙/绿淡色），日期文字颜色同步变化。点击标签弹出信息浮窗显示完整名称。

**兜底方案**：当 tyme 库暂无某年法定假日数据时，固定日期假日（元旦 1-1、劳动节 5-1、国庆 10-1）仍可降级显示「假」标签。依赖农历的变动假日（春节、清明、端午、中秋）不做降级。

### 对比旧方案（PR #122）

| 功能 | 旧方案 | 本 PR |
|------|--------|-------|
| 节假日标签 | ✅ | ✅ |
| 节气标签 | ✅ | ✅ |
| 节日标签 | ✅ | ✅ |
| 调休管理 UI | ✅ | ❌ 去除 |
| 调休数据库存储 | ✅ | ❌ 去除 |
| 通知搜索跳转 | ✅ | ❌ 去除 |
| 小组件同步 | ✅ | ❌ 去除 |
| 设置/取消放假 | ✅ | ❌ 去除 |
| 国际化学期 | 部分硬编码 | ✅ dateMonthDay 键 |
| 全量遍历 365 天 | ✅ | ❌ 改为 near 参数 ±30 天 |