### PR TITLE
Feat/class schedule inquiry

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -568,6 +568,7 @@
     "dockLabelClassroom": "Classroom",
     "dockLabelNetworkDevice": "Network",
     "dockLabelBalanceQuery": "Electricity",
+    "dockLabelClassScheduleInquiry": "Class Schedule Inquiry",
     "dockLabelAcademicCalendar": "Calendar",
     "fitnessTest": "Fitness Test",
     "fitnessTestDesc": "Query fitness test scores and view notices",
@@ -717,6 +718,19 @@
     "@solarTermTypeLabel": {
         "description": "Label for solar term type shown in special day detail sheet"
     },
+    "classScheduleInquiry": "Class Schedule Inquiry",
+    "classScheduleInquiryDesc": "View course schedules for each class",
+    "classScheduleInquiryNoData": "No class data",
+    "classScheduleInquiryNoSchedule": "No schedule data",
+    "classScheduleInquiryDetail": "Course Details",
+    "classScheduleInquiryFilter": "Filter",
+    "classScheduleInquirySemester": "Semester",
+    "classScheduleInquiryGrade": "Grade",
+    "classScheduleInquiryDepartment": "Department",
+    "classScheduleInquirySubject": "Major",
+    "classScheduleInquiryClass": "Class",
+    "classScheduleInquirySearch": "Search",
+    "classScheduleInquiryLoadMore": "Load More",
     "holidayTotalDays": "{days}-day holiday",
     "@holidayTotalDays": {
         "description": "Shows total holiday days, e.g. '3-day holiday'",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3067,6 +3067,12 @@ abstract class AppLocalizations {
   /// **'Electricity'**
   String get dockLabelBalanceQuery;
 
+  /// No description provided for @dockLabelClassScheduleInquiry.
+  ///
+  /// In en, this message translates to:
+  /// **'Class Schedule Inquiry'**
+  String get dockLabelClassScheduleInquiry;
+
   /// No description provided for @dockLabelAcademicCalendar.
   ///
   /// In en, this message translates to:
@@ -3678,6 +3684,84 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Solar Term'**
   String get solarTermTypeLabel;
+
+  /// No description provided for @classScheduleInquiry.
+  ///
+  /// In en, this message translates to:
+  /// **'Class Schedule Inquiry'**
+  String get classScheduleInquiry;
+
+  /// No description provided for @classScheduleInquiryDesc.
+  ///
+  /// In en, this message translates to:
+  /// **'View course schedules for each class'**
+  String get classScheduleInquiryDesc;
+
+  /// No description provided for @classScheduleInquiryNoData.
+  ///
+  /// In en, this message translates to:
+  /// **'No class data'**
+  String get classScheduleInquiryNoData;
+
+  /// No description provided for @classScheduleInquiryNoSchedule.
+  ///
+  /// In en, this message translates to:
+  /// **'No schedule data'**
+  String get classScheduleInquiryNoSchedule;
+
+  /// No description provided for @classScheduleInquiryDetail.
+  ///
+  /// In en, this message translates to:
+  /// **'Course Details'**
+  String get classScheduleInquiryDetail;
+
+  /// No description provided for @classScheduleInquiryFilter.
+  ///
+  /// In en, this message translates to:
+  /// **'Filter'**
+  String get classScheduleInquiryFilter;
+
+  /// No description provided for @classScheduleInquirySemester.
+  ///
+  /// In en, this message translates to:
+  /// **'Semester'**
+  String get classScheduleInquirySemester;
+
+  /// No description provided for @classScheduleInquiryGrade.
+  ///
+  /// In en, this message translates to:
+  /// **'Grade'**
+  String get classScheduleInquiryGrade;
+
+  /// No description provided for @classScheduleInquiryDepartment.
+  ///
+  /// In en, this message translates to:
+  /// **'Department'**
+  String get classScheduleInquiryDepartment;
+
+  /// No description provided for @classScheduleInquirySubject.
+  ///
+  /// In en, this message translates to:
+  /// **'Major'**
+  String get classScheduleInquirySubject;
+
+  /// No description provided for @classScheduleInquiryClass.
+  ///
+  /// In en, this message translates to:
+  /// **'Class'**
+  String get classScheduleInquiryClass;
+
+  /// No description provided for @classScheduleInquirySearch.
+  ///
+  /// In en, this message translates to:
+  /// **'Search'**
+  String get classScheduleInquirySearch;
+
+  /// No description provided for @classScheduleInquiryLoadMore.
+  ///
+  /// In en, this message translates to:
+  /// **'Load More'**
+  String get classScheduleInquiryLoadMore;
 
   /// Shows total holiday days, e.g. '3-day holiday'
   ///

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1592,6 +1592,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get dockLabelBalanceQuery => 'Electricity';
 
   @override
+  String get dockLabelClassScheduleInquiry => 'Class Schedule Inquiry';
+
+  @override
   String get dockLabelAcademicCalendar => 'Calendar';
 
   @override
@@ -1917,6 +1920,45 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get solarTermTypeLabel => 'Solar Term';
+
+  @override
+  String get classScheduleInquiry => 'Class Schedule Inquiry';
+
+  @override
+  String get classScheduleInquiryDesc => 'View course schedules for each class';
+
+  @override
+  String get classScheduleInquiryNoData => 'No class data';
+
+  @override
+  String get classScheduleInquiryNoSchedule => 'No schedule data';
+
+  @override
+  String get classScheduleInquiryDetail => 'Course Details';
+
+  @override
+  String get classScheduleInquiryFilter => 'Filter';
+
+  @override
+  String get classScheduleInquirySemester => 'Semester';
+
+  @override
+  String get classScheduleInquiryGrade => 'Grade';
+
+  @override
+  String get classScheduleInquiryDepartment => 'Department';
+
+  @override
+  String get classScheduleInquirySubject => 'Major';
+
+  @override
+  String get classScheduleInquiryClass => 'Class';
+
+  @override
+  String get classScheduleInquirySearch => 'Search';
+
+  @override
+  String get classScheduleInquiryLoadMore => 'Load More';
 
   @override
   String holidayTotalDays(int days) {

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1546,6 +1546,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get dockLabelBalanceQuery => '电费';
 
   @override
+  String get dockLabelClassScheduleInquiry => '班级课表';
+
+  @override
   String get dockLabelAcademicCalendar => '校历';
 
   @override
@@ -1862,6 +1865,45 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get solarTermTypeLabel => '节气';
+
+  @override
+  String get classScheduleInquiry => '班级课表';
+
+  @override
+  String get classScheduleInquiryDesc => '查看各班级的课表信息';
+
+  @override
+  String get classScheduleInquiryNoData => '暂无班级数据';
+
+  @override
+  String get classScheduleInquiryNoSchedule => '暂无课表数据';
+
+  @override
+  String get classScheduleInquiryDetail => '课程详情';
+
+  @override
+  String get classScheduleInquiryFilter => '查询条件';
+
+  @override
+  String get classScheduleInquirySemester => '学年学期';
+
+  @override
+  String get classScheduleInquiryGrade => '年级';
+
+  @override
+  String get classScheduleInquiryDepartment => '院系';
+
+  @override
+  String get classScheduleInquirySubject => '专业';
+
+  @override
+  String get classScheduleInquiryClass => '班级';
+
+  @override
+  String get classScheduleInquirySearch => '查询';
+
+  @override
+  String get classScheduleInquiryLoadMore => '加载更多';
 
   @override
   String holidayTotalDays(int days) {

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -563,6 +563,7 @@
     "dockLabelClassroom": "教室",
     "dockLabelNetworkDevice": "校园网",
     "dockLabelBalanceQuery": "电费",
+    "dockLabelClassScheduleInquiry": "班级课表",
     "dockLabelAcademicCalendar": "校历",
     "fitnessTest": "体质测试",
     "fitnessTestDesc": "查询体测成绩和查看通知公告",
@@ -712,6 +713,19 @@
     "@solarTermTypeLabel": {
         "description": "Label for solar term type shown in special day detail sheet"
     },
+    "classScheduleInquiry": "班级课表",
+    "classScheduleInquiryDesc": "查看各班级的课表信息",
+    "classScheduleInquiryNoData": "暂无班级数据",
+    "classScheduleInquiryNoSchedule": "暂无课表数据",
+    "classScheduleInquiryDetail": "课程详情",
+    "classScheduleInquiryFilter": "查询条件",
+    "classScheduleInquirySemester": "学年学期",
+    "classScheduleInquiryGrade": "年级",
+    "classScheduleInquiryDepartment": "院系",
+    "classScheduleInquirySubject": "专业",
+    "classScheduleInquiryClass": "班级",
+    "classScheduleInquirySearch": "查询",
+    "classScheduleInquiryLoadMore": "加载更多",
     "holidayTotalDays": "共{days}天假",
     "@holidayTotalDays": {
         "description": "Shows total holiday days, e.g. '共3天假'",

--- a/lib/models/campus_item_config.dart
+++ b/lib/models/campus_item_config.dart
@@ -4,6 +4,7 @@ import 'package:bugaoshan/utils/constants.dart';
 import 'package:bugaoshan/pages/campus/academic_calendar/academic_calendar_page.dart';
 import 'package:bugaoshan/pages/campus/balance_query/balance_query_page.dart';
 import 'package:bugaoshan/pages/campus/ccyl/ccyl_page.dart';
+import 'package:bugaoshan/pages/campus/class_schedule_inquiry/class_schedule_inquiry_page.dart';
 import 'package:bugaoshan/pages/campus/classroom/classroom_page.dart';
 import 'package:bugaoshan/pages/campus/downloads/notice_downloaded_page.dart';
 import 'package:bugaoshan/pages/campus/fitness_test/fitness_test_page.dart';
@@ -133,6 +134,16 @@ final campusItemClassroom = CampusItemConfig(
   page: () => const ClassroomPage(),
 );
 
+final campusItemClassScheduleInquiry = CampusItemConfig(
+  id: dockIdClassScheduleInquiry,
+  icon: Icons.calendar_view_week_outlined,
+  selectedIcon: Icons.calendar_view_week,
+  dockLabel: (l10n) => l10n.dockLabelClassScheduleInquiry,
+  dockFullLabel: (l10n) => l10n.classScheduleInquiry,
+  desc: (l10n) => l10n.classScheduleInquiryDesc,
+  page: () => const ClassScheduleInquiryPage(),
+);
+
 final campusItemNetworkDevice = CampusItemConfig(
   id: dockIdNetworkDevice,
   icon: Icons.router_outlined,
@@ -197,6 +208,7 @@ final campusSections = [
     title: (l10n) => l10n.utilitiesSection,
     items: [
       campusItemTrainProgram,
+      campusItemClassScheduleInquiry,
       campusItemClassroom,
       campusItemNetworkDevice,
       campusItemBalanceQuery,

--- a/lib/pages/campus/class_schedule_inquiry/class_schedule_inquiry_detail_page.dart
+++ b/lib/pages/campus/class_schedule_inquiry/class_schedule_inquiry_detail_page.dart
@@ -8,6 +8,7 @@ import 'package:bugaoshan/services/api/zhjw_api_service.dart';
 import 'package:bugaoshan/services/auth/scu_exceptions.dart';
 import 'package:bugaoshan/utils/week_parser.dart';
 import 'package:bugaoshan/widgets/course/course_grid.dart';
+import 'package:bugaoshan/widgets/course/course_detail_sheet.dart';
 
 /// 班级课表详情页 - 以课表网格展示班级课程
 class ClassScheduleInquiryDetailPage extends StatefulWidget {
@@ -148,6 +149,18 @@ class _ClassScheduleInquiryDetailPageState
           SizedBox(
             height: gridHeight,
             child: CourseGrid(
+              onCourseTap: (course) {
+                showModalBottomSheet(
+                  context: context,
+                  isScrollControlled: true,
+                  shape: const RoundedRectangleBorder(
+                    borderRadius: BorderRadius.vertical(
+                      top: Radius.circular(20),
+                    ),
+                  ),
+                  builder: (context) => CourseDetailSheet(course: course),
+                );
+              },
               courses: _courses.map(_toCourse).toList(),
               config: gridConfig,
               displayWeek: 1,

--- a/lib/pages/campus/class_schedule_inquiry/class_schedule_inquiry_detail_page.dart
+++ b/lib/pages/campus/class_schedule_inquiry/class_schedule_inquiry_detail_page.dart
@@ -25,15 +25,15 @@ class _ClassScheduleInquiryDetailPageState
   bool _isLoading = true;
   String? _error;
 
-  static const List<String> _dayLabels = [
+  static List<String> _buildDayLabels(AppLocalizations l10n) => [
     '',
-    '周一',
-    '周二',
-    '周三',
-    '周四',
-    '周五',
-    '周六',
-    '周日',
+    l10n.monday,
+    l10n.tuesday,
+    l10n.wednesday,
+    l10n.thursday,
+    l10n.friday,
+    l10n.saturday,
+    l10n.sunday,
   ];
 
   @override
@@ -151,6 +151,8 @@ class _ClassScheduleInquiryDetailPageState
 
   Widget _buildScheduleGrid(BuildContext context) {
     final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context)!;
+    final dayLabels = _buildDayLabels(l10n);
 
     // 检测是否有周末课程，决定显示5天还是7天
     final hasWeekend = _courses.any((c) => c.dayOfWeek > 5);
@@ -218,7 +220,7 @@ class _ClassScheduleInquiryDetailPageState
                     ),
                     child: Center(
                       child: Text(
-                        _dayLabels[dayIndex + 1],
+                        dayLabels[dayIndex + 1],
                         style: TextStyle(
                           fontSize: 13,
                           fontWeight: FontWeight.bold,

--- a/lib/pages/campus/class_schedule_inquiry/class_schedule_inquiry_detail_page.dart
+++ b/lib/pages/campus/class_schedule_inquiry/class_schedule_inquiry_detail_page.dart
@@ -141,7 +141,7 @@ class _ClassScheduleInquiryDetailPageState
     );
 
     return SingleChildScrollView(
-      padding: const EdgeInsets.all(12),
+      padding: const EdgeInsets.fromLTRB(2, 2, 2, 16),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [

--- a/lib/pages/campus/class_schedule_inquiry/class_schedule_inquiry_detail_page.dart
+++ b/lib/pages/campus/class_schedule_inquiry/class_schedule_inquiry_detail_page.dart
@@ -152,6 +152,10 @@ class _ClassScheduleInquiryDetailPageState
   Widget _buildScheduleGrid(BuildContext context) {
     final theme = Theme.of(context);
 
+    // 检测是否有周末课程，决定显示5天还是7天
+    final hasWeekend = _courses.any((c) => c.dayOfWeek > 5);
+    final dayCount = hasWeekend ? 7 : 5;
+
     // Build a map: dayOfWeek -> (startPeriod -> [courses])
     final Map<int, Map<int, List<ClassScheduleInquiryItem>>> gridMap = {};
     for (final course in _courses) {
@@ -197,7 +201,7 @@ class _ClassScheduleInquiryDetailPageState
                   ),
                 ),
               ),
-              ...List.generate(5, (dayIndex) {
+              ...List.generate(dayCount, (dayIndex) {
                 return Expanded(
                   child: Container(
                     decoration: BoxDecoration(
@@ -228,7 +232,7 @@ class _ClassScheduleInquiryDetailPageState
             ],
           ),
         ),
-        // Grid content: section column + 5 day stacks
+        // Grid content: section column + dayCount day stacks
         SizedBox(
           height: totalPeriods * rowHeight,
           child: Row(
@@ -242,7 +246,7 @@ class _ClassScheduleInquiryDetailPageState
               ),
               Expanded(
                 child: Row(
-                  children: List.generate(5, (dayIndex) {
+                  children: List.generate(dayCount, (dayIndex) {
                     return Expanded(
                       child: _buildDayColumn(
                         context,
@@ -355,7 +359,7 @@ class _ClassScheduleInquiryDetailPageState
               left: 1,
               right: 1,
               height: courseHeight,
-              child: _buildCourseCell(context, [course]),
+              child: _buildCourseCell(context, course),
             );
           }),
         ],
@@ -363,6 +367,8 @@ class _ClassScheduleInquiryDetailPageState
     );
   }
 
+  /// 将 API 课程项转为 Course 对象供 CourseCard 使用。
+  /// 班级课表不涉及周次切换，固定 1-20 周 + every 即可保证始终可见。
   Course _toCourse(ClassScheduleInquiryItem item) {
     return Course(
       name: item.courseName,
@@ -381,14 +387,12 @@ class _ClassScheduleInquiryDetailPageState
     );
   }
 
-  Widget _buildCourseCell(
-    BuildContext context,
-    List<ClassScheduleInquiryItem> items,
-  ) {
-    final item = items.first;
+  Widget _buildCourseCell(BuildContext context, ClassScheduleInquiryItem item) {
     final course = _toCourse(item);
+    // semesterStartDate 不影响显示：displayWeek=1 且 weekType=every 时
+    // CourseCard 不依赖实际日期计算，保持无状态即可。
     final config = ScheduleConfig(
-      semesterStartDate: DateTime.now(),
+      semesterStartDate: DateTime(2025, 9, 1),
       showTeacherName: true,
       showLocation: true,
     );

--- a/lib/pages/campus/class_schedule_inquiry/class_schedule_inquiry_detail_page.dart
+++ b/lib/pages/campus/class_schedule_inquiry/class_schedule_inquiry_detail_page.dart
@@ -1,0 +1,511 @@
+import 'package:flutter/material.dart';
+import 'package:bugaoshan/injection/injector.dart';
+import 'package:bugaoshan/l10n/app_localizations.dart';
+import 'package:bugaoshan/models/course.dart';
+import 'package:bugaoshan/pages/campus/models/class_schedule_inquiry_model.dart';
+import 'package:bugaoshan/services/api/zhjw_api_service.dart';
+import 'package:bugaoshan/services/auth/scu_exceptions.dart';
+import 'package:bugaoshan/widgets/course/course_card.dart';
+
+/// 班级课表详情页 - 以课表网格展示班级课程
+class ClassScheduleInquiryDetailPage extends StatefulWidget {
+  final ClassInfo classInfo;
+
+  const ClassScheduleInquiryDetailPage({super.key, required this.classInfo});
+
+  @override
+  State<ClassScheduleInquiryDetailPage> createState() =>
+      _ClassScheduleInquiryDetailPageState();
+}
+
+class _ClassScheduleInquiryDetailPageState
+    extends State<ClassScheduleInquiryDetailPage> {
+  late final ZhjwApiService _zhjwApi;
+  List<ClassScheduleInquiryItem> _courses = [];
+  bool _isLoading = true;
+  String? _error;
+
+  static const List<String> _dayLabels = [
+    '',
+    '周一',
+    '周二',
+    '周三',
+    '周四',
+    '周五',
+    '周六',
+    '周日',
+  ];
+
+  @override
+  void initState() {
+    super.initState();
+    _zhjwApi = getIt<ZhjwApiService>();
+    _loadSchedule();
+  }
+
+  Future<void> _loadSchedule() async {
+    setState(() {
+      _isLoading = true;
+      _error = null;
+    });
+    try {
+      final courses = await _zhjwApi.fetchClassSchedule(
+        planCode: widget.classInfo.planCode,
+        classCode: widget.classInfo.classCode,
+      );
+      if (!mounted) return;
+      setState(() {
+        _courses = courses;
+        _isLoading = false;
+      });
+    } on UnauthenticatedException catch (_) {
+      if (!mounted) return;
+      setState(() {
+        _error = 'sessionExpired';
+        _isLoading = false;
+      });
+    } catch (e) {
+      debugPrint('ClassScheduleInquiry detail load error: $e');
+      if (!mounted) return;
+      setState(() {
+        _error = 'loadFailed';
+        _isLoading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(widget.classInfo.className),
+            Text(
+              widget.classInfo.planName,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ),
+      ),
+      body: _buildBody(context, l10n),
+    );
+  }
+
+  Widget _buildBody(BuildContext context, AppLocalizations l10n) {
+    if (_isLoading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (_error != null) {
+      return Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(
+              _error == 'sessionExpired'
+                  ? l10n.sessionExpired
+                  : l10n.loadFailed,
+              style: Theme.of(context).textTheme.bodyLarge,
+            ),
+            const SizedBox(height: 16),
+            FilledButton(onPressed: _loadSchedule, child: Text(l10n.retry)),
+          ],
+        ),
+      );
+    }
+
+    if (_courses.isEmpty) {
+      return Center(
+        child: Text(
+          l10n.classScheduleInquiryNoSchedule,
+          style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+            color: Theme.of(context).colorScheme.onSurfaceVariant,
+          ),
+        ),
+      );
+    }
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _buildScheduleGrid(context),
+          const SizedBox(height: 24),
+          Text(
+            l10n.classScheduleInquiryDetail,
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          const SizedBox(height: 8),
+          _buildCourseList(context),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildScheduleGrid(BuildContext context) {
+    final theme = Theme.of(context);
+
+    // Build a map: dayOfWeek -> (startPeriod -> [courses])
+    final Map<int, Map<int, List<ClassScheduleInquiryItem>>> gridMap = {};
+    for (final course in _courses) {
+      gridMap.putIfAbsent(course.dayOfWeek, () => {});
+      for (
+        int p = course.startPeriod;
+        p < course.startPeriod + course.duration;
+        p++
+      ) {
+        gridMap[course.dayOfWeek]!.putIfAbsent(p, () => []);
+        if (gridMap[course.dayOfWeek]![p]!.length < 2) {
+          gridMap[course.dayOfWeek]![p]!.add(course);
+        }
+      }
+    }
+
+    const double sectionWidth = 35;
+    const double rowHeight = 72;
+    const int totalPeriods = 12;
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        // Header row
+        SizedBox(
+          height: 40,
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              SizedBox(
+                width: sectionWidth,
+                child: Container(
+                  decoration: BoxDecoration(
+                    border: Border(
+                      right: BorderSide(
+                        color: theme.colorScheme.outlineVariant,
+                        width: 0.5,
+                      ),
+                      bottom: BorderSide(
+                        color: theme.colorScheme.outlineVariant,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              ...List.generate(5, (dayIndex) {
+                return Expanded(
+                  child: Container(
+                    decoration: BoxDecoration(
+                      color: theme.colorScheme.surfaceContainerHighest,
+                      border: Border(
+                        bottom: BorderSide(
+                          color: theme.colorScheme.outlineVariant,
+                        ),
+                        right: BorderSide(
+                          color: theme.colorScheme.outlineVariant,
+                          width: 0.5,
+                        ),
+                      ),
+                    ),
+                    child: Center(
+                      child: Text(
+                        _dayLabels[dayIndex + 1],
+                        style: TextStyle(
+                          fontSize: 13,
+                          fontWeight: FontWeight.bold,
+                          color: theme.colorScheme.onSurface,
+                        ),
+                      ),
+                    ),
+                  ),
+                );
+              }),
+            ],
+          ),
+        ),
+        // Grid content: section column + 5 day stacks
+        SizedBox(
+          height: totalPeriods * rowHeight,
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              _buildSectionColumn(
+                context,
+                totalPeriods,
+                sectionWidth,
+                rowHeight,
+              ),
+              Expanded(
+                child: Row(
+                  children: List.generate(5, (dayIndex) {
+                    return Expanded(
+                      child: _buildDayColumn(
+                        context,
+                        dayIndex + 1,
+                        gridMap,
+                        totalPeriods,
+                        rowHeight,
+                      ),
+                    );
+                  }),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSectionColumn(
+    BuildContext context,
+    int totalPeriods,
+    double sectionWidth,
+    double rowHeight,
+  ) {
+    final theme = Theme.of(context);
+    return SizedBox(
+      width: sectionWidth,
+      child: Column(
+        children: List.generate(totalPeriods, (i) {
+          final period = i + 1;
+          return Container(
+            height: rowHeight,
+            decoration: BoxDecoration(
+              border: Border(
+                right: BorderSide(
+                  color: theme.colorScheme.outlineVariant,
+                  width: 0.5,
+                ),
+                bottom: BorderSide(
+                  color: theme.colorScheme.outlineVariant,
+                  width: 0.5,
+                ),
+              ),
+            ),
+            child: Center(
+              child: Text(
+                '$period',
+                style: const TextStyle(
+                  fontSize: 13,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+          );
+        }),
+      ),
+    );
+  }
+
+  Widget _buildDayColumn(
+    BuildContext context,
+    int dayOfWeek,
+    Map<int, Map<int, List<ClassScheduleInquiryItem>>> gridMap,
+    int totalPeriods,
+    double rowHeight,
+  ) {
+    final theme = Theme.of(context);
+
+    // Collect unique courses for this day
+    final dayCourses = <ClassScheduleInquiryItem>{};
+    for (int p = 1; p <= totalPeriods; p++) {
+      final courses = gridMap[dayOfWeek]?[p] ?? [];
+      dayCourses.addAll(courses);
+    }
+
+    return SizedBox(
+      height: totalPeriods * rowHeight,
+      child: Stack(
+        children: [
+          // Grid lines
+          ...List.generate(totalPeriods, (i) {
+            return Positioned(
+              top: i * rowHeight,
+              left: 0,
+              right: 0,
+              height: rowHeight,
+              child: Container(
+                decoration: BoxDecoration(
+                  border: Border(
+                    bottom: BorderSide(
+                      color: theme.colorScheme.outlineVariant,
+                      width: 0.5,
+                    ),
+                    right: BorderSide(
+                      color: theme.colorScheme.outlineVariant,
+                      width: 0.5,
+                    ),
+                  ),
+                ),
+              ),
+            );
+          }),
+          // Course cards
+          ...dayCourses.map((course) {
+            final top = (course.startPeriod - 1) * rowHeight;
+            final courseHeight = course.duration * rowHeight - 2;
+            return Positioned(
+              top: top + 1,
+              left: 1,
+              right: 1,
+              height: courseHeight,
+              child: _buildCourseCell(context, [course]),
+            );
+          }),
+        ],
+      ),
+    );
+  }
+
+  Course _toCourse(ClassScheduleInquiryItem item) {
+    return Course(
+      name: item.courseName,
+      teacher: item.teacherName,
+      location: [
+        item.building,
+        item.classroom,
+      ].where((s) => s.isNotEmpty).join(' '),
+      startWeek: 1,
+      endWeek: 20,
+      dayOfWeek: item.dayOfWeek,
+      startSection: item.startPeriod,
+      endSection: item.startPeriod + item.duration - 1,
+      colorValue: _getCourseColor(item.courseCode).toARGB32(),
+      weekType: WeekType.every,
+    );
+  }
+
+  Widget _buildCourseCell(
+    BuildContext context,
+    List<ClassScheduleInquiryItem> items,
+  ) {
+    final item = items.first;
+    final course = _toCourse(item);
+    final config = ScheduleConfig(
+      semesterStartDate: DateTime.now(),
+      showTeacherName: true,
+      showLocation: true,
+    );
+    return Padding(
+      padding: const EdgeInsets.all(1),
+      child: CourseCard(course: course, config: config, displayWeek: 1),
+    );
+  }
+
+  Widget _buildCourseList(BuildContext context) {
+    final theme = Theme.of(context);
+    return Column(
+      children: _courses.asMap().entries.map((entry) {
+        final course = entry.value;
+        final color = _getCourseColor(course.courseCode);
+        return Card(
+          margin: const EdgeInsets.only(bottom: 8),
+          child: Padding(
+            padding: const EdgeInsets.all(12),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Container(
+                  width: 4,
+                  height: 80,
+                  decoration: BoxDecoration(
+                    color: color,
+                    borderRadius: BorderRadius.circular(2),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        course.courseName,
+                        style: theme.textTheme.titleSmall?.copyWith(
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        '${course.courseCode} · ${course.courseSeq}',
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                      const SizedBox(height: 4),
+                      _buildInfoRow(
+                        Icons.person_outline,
+                        course.teacherName,
+                        theme,
+                      ),
+                      _buildInfoRow(
+                        Icons.date_range,
+                        course.weeksDescription,
+                        theme,
+                      ),
+                      if (course.classroom.isNotEmpty)
+                        _buildInfoRow(
+                          Icons.room_outlined,
+                          [
+                            course.campus,
+                            course.building,
+                            course.classroom,
+                          ].where((s) => s.isNotEmpty).join(' '),
+                          theme,
+                        ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      }).toList(),
+    );
+  }
+
+  Widget _buildInfoRow(IconData icon, String text, ThemeData theme) {
+    if (text.isEmpty) return const SizedBox.shrink();
+    return Padding(
+      padding: const EdgeInsets.only(top: 2),
+      child: Row(
+        children: [
+          Icon(icon, size: 14, color: theme.colorScheme.onSurfaceVariant),
+          const SizedBox(width: 4),
+          Expanded(
+            child: Text(
+              text,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Color _getCourseColor(String courseCode) {
+    final hash = courseCode.hashCode;
+    final colors = [
+      Colors.blue,
+      Colors.teal,
+      Colors.orange,
+      Colors.purple,
+      Colors.pink,
+      Colors.indigo,
+      Colors.green,
+      Colors.deepOrange,
+      Colors.cyan,
+      Colors.brown,
+    ];
+    return colors[hash.abs() % colors.length];
+  }
+}

--- a/lib/pages/campus/class_schedule_inquiry/class_schedule_inquiry_detail_page.dart
+++ b/lib/pages/campus/class_schedule_inquiry/class_schedule_inquiry_detail_page.dart
@@ -3,9 +3,10 @@ import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/models/course.dart';
 import 'package:bugaoshan/pages/campus/models/class_schedule_inquiry_model.dart';
+import 'package:bugaoshan/providers/app_config_provider.dart';
 import 'package:bugaoshan/services/api/zhjw_api_service.dart';
 import 'package:bugaoshan/services/auth/scu_exceptions.dart';
-import 'package:bugaoshan/widgets/course/course_card.dart';
+import 'package:bugaoshan/widgets/course/course_grid.dart';
 
 /// 班级课表详情页 - 以课表网格展示班级课程
 class ClassScheduleInquiryDetailPage extends StatefulWidget {
@@ -25,16 +26,30 @@ class _ClassScheduleInquiryDetailPageState
   bool _isLoading = true;
   String? _error;
 
-  static List<String> _buildDayLabels(AppLocalizations l10n) => [
-    '',
-    l10n.monday,
-    l10n.tuesday,
-    l10n.wednesday,
-    l10n.thursday,
-    l10n.friday,
-    l10n.saturday,
-    l10n.sunday,
-  ];
+  /// 将教务系统周次描述解析为 Course 的周次参数。
+  /// zcsm 格式如 "1-10周"、"1-10,12周"、"1-16(单)" 等。
+  (int startWeek, int endWeek, WeekType weekType) _parseWeeks(String zcsm) {
+    if (zcsm.isEmpty) return (1, 20, WeekType.every);
+    final text = zcsm.replaceAll('周', '').trim();
+    WeekType weekType = WeekType.every;
+    if (text.contains('单')) weekType = WeekType.odd;
+    if (text.contains('双')) weekType = WeekType.even;
+    final numbers = text.replaceAll(RegExp(r'[^\d,\-]'), '');
+    final parts = numbers.split(',');
+    int startWeek = 1, endWeek = 20;
+    for (final part in parts) {
+      final range = part.split('-');
+      if (range.length == 2) {
+        final s = int.tryParse(range[0]);
+        final e = int.tryParse(range[1]);
+        if (s != null && e != null) {
+          if (startWeek == 1 || s < startWeek) startWeek = s;
+          if (endWeek == 20 || e > endWeek) endWeek = e;
+        }
+      }
+    }
+    return (startWeek, endWeek, weekType);
+  }
 
   @override
   void initState() {
@@ -131,12 +146,38 @@ class _ClassScheduleInquiryDetailPageState
       );
     }
 
+    final hasWeekend = _courses.any((c) => c.dayOfWeek > 5);
+    final rowHeight = getIt<AppConfigProvider>().courseRowHeight.value;
+    const headerHeight = 40.0;
+    const int totalPeriods = 12;
+    final gridHeight = headerHeight + totalPeriods * rowHeight;
+
+    final gridConfig = ScheduleConfig(
+      semesterStartDate: DateTime(2025, 9, 1),
+      showTeacherName: true,
+      showLocation: true,
+      showWeekend: hasWeekend,
+      morningSections: 0,
+      afternoonSections: 0,
+      eveningSections: totalPeriods,
+      timeSlots: [],
+    );
+
     return SingleChildScrollView(
       padding: const EdgeInsets.all(12),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          _buildScheduleGrid(context),
+          SizedBox(
+            height: gridHeight,
+            child: CourseGrid(
+              courses: _courses.map(_toCourse).toList(),
+              config: gridConfig,
+              displayWeek: 1,
+              totalWeeks: 20,
+              forceActive: true,
+            ),
+          ),
           const SizedBox(height: 24),
           Text(
             l10n.classScheduleInquiryDetail,
@@ -149,229 +190,9 @@ class _ClassScheduleInquiryDetailPageState
     );
   }
 
-  Widget _buildScheduleGrid(BuildContext context) {
-    final theme = Theme.of(context);
-    final l10n = AppLocalizations.of(context)!;
-    final dayLabels = _buildDayLabels(l10n);
-
-    // 检测是否有周末课程，决定显示5天还是7天
-    final hasWeekend = _courses.any((c) => c.dayOfWeek > 5);
-    final dayCount = hasWeekend ? 7 : 5;
-
-    // Build a map: dayOfWeek -> (startPeriod -> [courses])
-    final Map<int, Map<int, List<ClassScheduleInquiryItem>>> gridMap = {};
-    for (final course in _courses) {
-      gridMap.putIfAbsent(course.dayOfWeek, () => {});
-      for (
-        int p = course.startPeriod;
-        p < course.startPeriod + course.duration;
-        p++
-      ) {
-        gridMap[course.dayOfWeek]!.putIfAbsent(p, () => []);
-        if (gridMap[course.dayOfWeek]![p]!.length < 2) {
-          gridMap[course.dayOfWeek]![p]!.add(course);
-        }
-      }
-    }
-
-    const double sectionWidth = 35;
-    const double rowHeight = 72;
-    const int totalPeriods = 12;
-
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        // Header row
-        SizedBox(
-          height: 40,
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              SizedBox(
-                width: sectionWidth,
-                child: Container(
-                  decoration: BoxDecoration(
-                    border: Border(
-                      right: BorderSide(
-                        color: theme.colorScheme.outlineVariant,
-                        width: 0.5,
-                      ),
-                      bottom: BorderSide(
-                        color: theme.colorScheme.outlineVariant,
-                      ),
-                    ),
-                  ),
-                ),
-              ),
-              ...List.generate(dayCount, (dayIndex) {
-                return Expanded(
-                  child: Container(
-                    decoration: BoxDecoration(
-                      color: theme.colorScheme.surfaceContainerHighest,
-                      border: Border(
-                        bottom: BorderSide(
-                          color: theme.colorScheme.outlineVariant,
-                        ),
-                        right: BorderSide(
-                          color: theme.colorScheme.outlineVariant,
-                          width: 0.5,
-                        ),
-                      ),
-                    ),
-                    child: Center(
-                      child: Text(
-                        dayLabels[dayIndex + 1],
-                        style: TextStyle(
-                          fontSize: 13,
-                          fontWeight: FontWeight.bold,
-                          color: theme.colorScheme.onSurface,
-                        ),
-                      ),
-                    ),
-                  ),
-                );
-              }),
-            ],
-          ),
-        ),
-        // Grid content: section column + dayCount day stacks
-        SizedBox(
-          height: totalPeriods * rowHeight,
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              _buildSectionColumn(
-                context,
-                totalPeriods,
-                sectionWidth,
-                rowHeight,
-              ),
-              Expanded(
-                child: Row(
-                  children: List.generate(dayCount, (dayIndex) {
-                    return Expanded(
-                      child: _buildDayColumn(
-                        context,
-                        dayIndex + 1,
-                        gridMap,
-                        totalPeriods,
-                        rowHeight,
-                      ),
-                    );
-                  }),
-                ),
-              ),
-            ],
-          ),
-        ),
-      ],
-    );
-  }
-
-  Widget _buildSectionColumn(
-    BuildContext context,
-    int totalPeriods,
-    double sectionWidth,
-    double rowHeight,
-  ) {
-    final theme = Theme.of(context);
-    return SizedBox(
-      width: sectionWidth,
-      child: Column(
-        children: List.generate(totalPeriods, (i) {
-          final period = i + 1;
-          return Container(
-            height: rowHeight,
-            decoration: BoxDecoration(
-              border: Border(
-                right: BorderSide(
-                  color: theme.colorScheme.outlineVariant,
-                  width: 0.5,
-                ),
-                bottom: BorderSide(
-                  color: theme.colorScheme.outlineVariant,
-                  width: 0.5,
-                ),
-              ),
-            ),
-            child: Center(
-              child: Text(
-                '$period',
-                style: const TextStyle(
-                  fontSize: 13,
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
-            ),
-          );
-        }),
-      ),
-    );
-  }
-
-  Widget _buildDayColumn(
-    BuildContext context,
-    int dayOfWeek,
-    Map<int, Map<int, List<ClassScheduleInquiryItem>>> gridMap,
-    int totalPeriods,
-    double rowHeight,
-  ) {
-    final theme = Theme.of(context);
-
-    // Collect unique courses for this day
-    final dayCourses = <ClassScheduleInquiryItem>{};
-    for (int p = 1; p <= totalPeriods; p++) {
-      final courses = gridMap[dayOfWeek]?[p] ?? [];
-      dayCourses.addAll(courses);
-    }
-
-    return SizedBox(
-      height: totalPeriods * rowHeight,
-      child: Stack(
-        children: [
-          // Grid lines
-          ...List.generate(totalPeriods, (i) {
-            return Positioned(
-              top: i * rowHeight,
-              left: 0,
-              right: 0,
-              height: rowHeight,
-              child: Container(
-                decoration: BoxDecoration(
-                  border: Border(
-                    bottom: BorderSide(
-                      color: theme.colorScheme.outlineVariant,
-                      width: 0.5,
-                    ),
-                    right: BorderSide(
-                      color: theme.colorScheme.outlineVariant,
-                      width: 0.5,
-                    ),
-                  ),
-                ),
-              ),
-            );
-          }),
-          // Course cards
-          ...dayCourses.map((course) {
-            final top = (course.startPeriod - 1) * rowHeight;
-            final courseHeight = course.duration * rowHeight - 2;
-            return Positioned(
-              top: top + 1,
-              left: 1,
-              right: 1,
-              height: courseHeight,
-              child: _buildCourseCell(context, course),
-            );
-          }),
-        ],
-      ),
-    );
-  }
-
-  /// 将 API 课程项转为 Course 对象供 CourseCard 使用。
-  /// 班级课表不涉及周次切换，固定 1-20 周 + every 即可保证始终可见。
+  /// 将 API 课程项转为 Course 对象。
   Course _toCourse(ClassScheduleInquiryItem item) {
+    final (startWeek, endWeek, weekType) = _parseWeeks(item.weeksDescription);
     return Course(
       name: item.courseName,
       teacher: item.teacherName,
@@ -379,28 +200,13 @@ class _ClassScheduleInquiryDetailPageState
         item.building,
         item.classroom,
       ].where((s) => s.isNotEmpty).join(' '),
-      startWeek: 1,
-      endWeek: 20,
+      startWeek: startWeek,
+      endWeek: endWeek,
       dayOfWeek: item.dayOfWeek,
       startSection: item.startPeriod,
       endSection: item.startPeriod + item.duration - 1,
       colorValue: _getCourseColor(item.courseCode).toARGB32(),
-      weekType: WeekType.every,
-    );
-  }
-
-  Widget _buildCourseCell(BuildContext context, ClassScheduleInquiryItem item) {
-    final course = _toCourse(item);
-    // semesterStartDate 不影响显示：displayWeek=1 且 weekType=every 时
-    // CourseCard 不依赖实际日期计算，保持无状态即可。
-    final config = ScheduleConfig(
-      semesterStartDate: DateTime(2025, 9, 1),
-      showTeacherName: true,
-      showLocation: true,
-    );
-    return Padding(
-      padding: const EdgeInsets.all(1),
-      child: CourseCard(course: course, config: config, displayWeek: 1),
+      weekType: weekType,
     );
   }
 

--- a/lib/pages/campus/class_schedule_inquiry/class_schedule_inquiry_detail_page.dart
+++ b/lib/pages/campus/class_schedule_inquiry/class_schedule_inquiry_detail_page.dart
@@ -27,7 +27,7 @@ class _ClassScheduleInquiryDetailPageState
   String? _error;
 
   /// 将教务系统周次描述解析为 Course 的周次参数。
-  /// zcsm 格式如 "1-10周"、"1-10,12周"、"1-16(单)" 等。
+  /// zcsm 格式如 "1-10周"、"1-10,12周"、"1-16(单)"、"第16周" 等。
   (int startWeek, int endWeek, WeekType weekType) _parseWeeks(String zcsm) {
     if (zcsm.isEmpty) return (1, 20, WeekType.every);
     final text = zcsm.replaceAll('周', '').trim();
@@ -35,20 +35,28 @@ class _ClassScheduleInquiryDetailPageState
     if (text.contains('单')) weekType = WeekType.odd;
     if (text.contains('双')) weekType = WeekType.even;
     final numbers = text.replaceAll(RegExp(r'[^\d,\-]'), '');
+    if (numbers.isEmpty) return (1, 20, weekType);
     final parts = numbers.split(',');
-    int startWeek = 1, endWeek = 20;
+    int? minStart;
+    int? maxEnd;
     for (final part in parts) {
       final range = part.split('-');
       if (range.length == 2) {
         final s = int.tryParse(range[0]);
         final e = int.tryParse(range[1]);
         if (s != null && e != null) {
-          if (startWeek == 1 || s < startWeek) startWeek = s;
-          if (endWeek == 20 || e > endWeek) endWeek = e;
+          minStart = minStart == null ? s : (s < minStart ? s : minStart);
+          maxEnd = maxEnd == null ? e : (e > maxEnd ? e : maxEnd);
+        }
+      } else if (range.length == 1) {
+        final w = int.tryParse(range[0]);
+        if (w != null) {
+          minStart = minStart == null ? w : (w < minStart ? w : minStart);
+          maxEnd = maxEnd == null ? w : (w > maxEnd ? w : maxEnd);
         }
       }
     }
-    return (startWeek, endWeek, weekType);
+    return (minStart ?? 1, maxEnd ?? 20, weekType);
   }
 
   @override
@@ -212,10 +220,34 @@ class _ClassScheduleInquiryDetailPageState
 
   Widget _buildCourseList(BuildContext context) {
     final theme = Theme.of(context);
+    // Merge same-name same-slot items for display
+    final groups = <String, List<ClassScheduleInquiryItem>>{};
+    for (final item in _courses) {
+      final key =
+          '${item.courseName}|${item.dayOfWeek}|${item.startPeriod}|${item.duration}';
+      groups.putIfAbsent(key, () => []).add(item);
+    }
+
     return Column(
-      children: _courses.asMap().entries.map((entry) {
-        final course = entry.value;
-        final color = _getCourseColor(course.courseCode);
+      children: groups.values.map((group) {
+        group.sort((a, b) => a.weeksDescription.compareTo(b.weeksDescription));
+        final first = group.first;
+        final color = _getCourseColor(first.courseCode);
+
+        // Build merged info strings (no week annotations — shown in header)
+        final teacherInfo = group.map((c) => c.teacherName).toSet().join('、');
+
+        final locationInfo = group
+            .map(
+              (c) => [
+                c.campus,
+                c.building,
+                c.classroom,
+              ].where((s) => s.isNotEmpty).join(' '),
+            )
+            .toSet()
+            .join(' · ');
+
         return Card(
           margin: const EdgeInsets.only(bottom: 8),
           child: Padding(
@@ -237,39 +269,41 @@ class _ClassScheduleInquiryDetailPageState
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Text(
-                        course.courseName,
+                        first.courseName,
                         style: theme.textTheme.titleSmall?.copyWith(
                           fontWeight: FontWeight.w600,
                         ),
                       ),
                       const SizedBox(height: 4),
                       Text(
-                        '${course.courseCode} · ${course.courseSeq}',
+                        '${first.courseCode} · ${first.courseSeq}',
                         style: theme.textTheme.bodySmall?.copyWith(
                           color: theme.colorScheme.onSurfaceVariant,
                         ),
                       ),
                       const SizedBox(height: 4),
-                      _buildInfoRow(
-                        Icons.person_outline,
-                        course.teacherName,
-                        theme,
-                      ),
+                      _buildInfoRow(Icons.person_outline, teacherInfo, theme),
                       _buildInfoRow(
                         Icons.date_range,
-                        course.weeksDescription,
+                        group.length == 1
+                            ? first.weeksDescription
+                            : () {
+                                final minW = group
+                                    .map(
+                                      (c) => _parseWeeks(c.weeksDescription).$1,
+                                    )
+                                    .reduce((a, b) => a < b ? a : b);
+                                final maxW = group
+                                    .map(
+                                      (c) => _parseWeeks(c.weeksDescription).$2,
+                                    )
+                                    .reduce((a, b) => a > b ? a : b);
+                                return '$minW-$maxW周';
+                              }(),
                         theme,
                       ),
-                      if (course.classroom.isNotEmpty)
-                        _buildInfoRow(
-                          Icons.room_outlined,
-                          [
-                            course.campus,
-                            course.building,
-                            course.classroom,
-                          ].where((s) => s.isNotEmpty).join(' '),
-                          theme,
-                        ),
+                      if (group.any((c) => c.classroom.isNotEmpty))
+                        _buildInfoRow(Icons.room_outlined, locationInfo, theme),
                     ],
                   ),
                 ),

--- a/lib/pages/campus/class_schedule_inquiry/class_schedule_inquiry_detail_page.dart
+++ b/lib/pages/campus/class_schedule_inquiry/class_schedule_inquiry_detail_page.dart
@@ -175,7 +175,7 @@ class _ClassScheduleInquiryDetailPageState
               config: gridConfig,
               displayWeek: 1,
               totalWeeks: 20,
-              forceActive: true,
+              showAllWeeks: true,
             ),
           ),
           const SizedBox(height: 24),

--- a/lib/pages/campus/class_schedule_inquiry/class_schedule_inquiry_detail_page.dart
+++ b/lib/pages/campus/class_schedule_inquiry/class_schedule_inquiry_detail_page.dart
@@ -6,6 +6,7 @@ import 'package:bugaoshan/pages/campus/models/class_schedule_inquiry_model.dart'
 import 'package:bugaoshan/providers/app_config_provider.dart';
 import 'package:bugaoshan/services/api/zhjw_api_service.dart';
 import 'package:bugaoshan/services/auth/scu_exceptions.dart';
+import 'package:bugaoshan/utils/week_parser.dart';
 import 'package:bugaoshan/widgets/course/course_grid.dart';
 
 /// 班级课表详情页 - 以课表网格展示班级课程
@@ -25,39 +26,6 @@ class _ClassScheduleInquiryDetailPageState
   List<ClassScheduleInquiryItem> _courses = [];
   bool _isLoading = true;
   String? _error;
-
-  /// 将教务系统周次描述解析为 Course 的周次参数。
-  /// zcsm 格式如 "1-10周"、"1-10,12周"、"1-16(单)"、"第16周" 等。
-  (int startWeek, int endWeek, WeekType weekType) _parseWeeks(String zcsm) {
-    if (zcsm.isEmpty) return (1, 20, WeekType.every);
-    final text = zcsm.replaceAll('周', '').trim();
-    WeekType weekType = WeekType.every;
-    if (text.contains('单')) weekType = WeekType.odd;
-    if (text.contains('双')) weekType = WeekType.even;
-    final numbers = text.replaceAll(RegExp(r'[^\d,\-]'), '');
-    if (numbers.isEmpty) return (1, 20, weekType);
-    final parts = numbers.split(',');
-    int? minStart;
-    int? maxEnd;
-    for (final part in parts) {
-      final range = part.split('-');
-      if (range.length == 2) {
-        final s = int.tryParse(range[0]);
-        final e = int.tryParse(range[1]);
-        if (s != null && e != null) {
-          minStart = minStart == null ? s : (s < minStart ? s : minStart);
-          maxEnd = maxEnd == null ? e : (e > maxEnd ? e : maxEnd);
-        }
-      } else if (range.length == 1) {
-        final w = int.tryParse(range[0]);
-        if (w != null) {
-          minStart = minStart == null ? w : (w < minStart ? w : minStart);
-          maxEnd = maxEnd == null ? w : (w > maxEnd ? w : maxEnd);
-        }
-      }
-    }
-    return (minStart ?? 1, maxEnd ?? 20, weekType);
-  }
 
   @override
   void initState() {
@@ -160,6 +128,7 @@ class _ClassScheduleInquiryDetailPageState
     const int totalPeriods = 12;
     final gridHeight = headerHeight + totalPeriods * rowHeight;
 
+    // showAllWeeks 模式不读取 semesterStartDate，设任意值即可
     final gridConfig = ScheduleConfig(
       semesterStartDate: DateTime(2025, 9, 1),
       showTeacherName: true,
@@ -182,17 +151,9 @@ class _ClassScheduleInquiryDetailPageState
               courses: _courses.map(_toCourse).toList(),
               config: gridConfig,
               displayWeek: 1,
-              totalWeeks: 20,
               showAllWeeks: true,
             ),
           ),
-          const SizedBox(height: 24),
-          Text(
-            l10n.classScheduleInquiryDetail,
-            style: Theme.of(context).textTheme.titleMedium,
-          ),
-          const SizedBox(height: 8),
-          _buildCourseList(context),
         ],
       ),
     );
@@ -200,7 +161,7 @@ class _ClassScheduleInquiryDetailPageState
 
   /// 将 API 课程项转为 Course 对象。
   Course _toCourse(ClassScheduleInquiryItem item) {
-    final (startWeek, endWeek, weekType) = _parseWeeks(item.weeksDescription);
+    final (startWeek, endWeek, weekType) = parseWeeks(item.weeksDescription);
     return Course(
       name: item.courseName,
       teacher: item.teacherName,
@@ -215,126 +176,6 @@ class _ClassScheduleInquiryDetailPageState
       endSection: item.startPeriod + item.duration - 1,
       colorValue: _getCourseColor(item.courseCode).toARGB32(),
       weekType: weekType,
-    );
-  }
-
-  Widget _buildCourseList(BuildContext context) {
-    final theme = Theme.of(context);
-    // Merge same-name same-slot items for display
-    final groups = <String, List<ClassScheduleInquiryItem>>{};
-    for (final item in _courses) {
-      final key =
-          '${item.courseName}|${item.dayOfWeek}|${item.startPeriod}|${item.duration}';
-      groups.putIfAbsent(key, () => []).add(item);
-    }
-
-    return Column(
-      children: groups.values.map((group) {
-        group.sort((a, b) => a.weeksDescription.compareTo(b.weeksDescription));
-        final first = group.first;
-        final color = _getCourseColor(first.courseCode);
-
-        // Build merged info strings (no week annotations — shown in header)
-        final teacherInfo = group.map((c) => c.teacherName).toSet().join('、');
-
-        final locationInfo = group
-            .map(
-              (c) => [
-                c.campus,
-                c.building,
-                c.classroom,
-              ].where((s) => s.isNotEmpty).join(' '),
-            )
-            .toSet()
-            .join(' · ');
-
-        return Card(
-          margin: const EdgeInsets.only(bottom: 8),
-          child: Padding(
-            padding: const EdgeInsets.all(12),
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Container(
-                  width: 4,
-                  height: 80,
-                  decoration: BoxDecoration(
-                    color: color,
-                    borderRadius: BorderRadius.circular(2),
-                  ),
-                ),
-                const SizedBox(width: 12),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        first.courseName,
-                        style: theme.textTheme.titleSmall?.copyWith(
-                          fontWeight: FontWeight.w600,
-                        ),
-                      ),
-                      const SizedBox(height: 4),
-                      Text(
-                        '${first.courseCode} · ${first.courseSeq}',
-                        style: theme.textTheme.bodySmall?.copyWith(
-                          color: theme.colorScheme.onSurfaceVariant,
-                        ),
-                      ),
-                      const SizedBox(height: 4),
-                      _buildInfoRow(Icons.person_outline, teacherInfo, theme),
-                      _buildInfoRow(
-                        Icons.date_range,
-                        group.length == 1
-                            ? first.weeksDescription
-                            : () {
-                                final minW = group
-                                    .map(
-                                      (c) => _parseWeeks(c.weeksDescription).$1,
-                                    )
-                                    .reduce((a, b) => a < b ? a : b);
-                                final maxW = group
-                                    .map(
-                                      (c) => _parseWeeks(c.weeksDescription).$2,
-                                    )
-                                    .reduce((a, b) => a > b ? a : b);
-                                return '$minW-$maxW周';
-                              }(),
-                        theme,
-                      ),
-                      if (group.any((c) => c.classroom.isNotEmpty))
-                        _buildInfoRow(Icons.room_outlined, locationInfo, theme),
-                    ],
-                  ),
-                ),
-              ],
-            ),
-          ),
-        );
-      }).toList(),
-    );
-  }
-
-  Widget _buildInfoRow(IconData icon, String text, ThemeData theme) {
-    if (text.isEmpty) return const SizedBox.shrink();
-    return Padding(
-      padding: const EdgeInsets.only(top: 2),
-      child: Row(
-        children: [
-          Icon(icon, size: 14, color: theme.colorScheme.onSurfaceVariant),
-          const SizedBox(width: 4),
-          Expanded(
-            child: Text(
-              text,
-              style: theme.textTheme.bodySmall?.copyWith(
-                color: theme.colorScheme.onSurfaceVariant,
-              ),
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-            ),
-          ),
-        ],
-      ),
     );
   }
 

--- a/lib/pages/campus/class_schedule_inquiry/class_schedule_inquiry_page.dart
+++ b/lib/pages/campus/class_schedule_inquiry/class_schedule_inquiry_page.dart
@@ -27,7 +27,8 @@ class _ClassScheduleInquiryPageState extends State<ClassScheduleInquiryPage> {
   bool _hasMore = true;
   int _pageNum = 1;
   static const int _pageSize = 30;
-  int _requestSeq = 0;
+  int _subjectReqSeq = 0;
+  int _classOptionReqSeq = 0;
   String? _error;
 
   // 筛选选项
@@ -93,7 +94,7 @@ class _ClassScheduleInquiryPageState extends State<ClassScheduleInquiryPage> {
   }
 
   Future<void> _loadSubjects(String departmentNum) async {
-    final seq = ++_requestSeq;
+    final seq = ++_subjectReqSeq;
     if (departmentNum.isEmpty) {
       setState(() {
         _subjects = [];
@@ -103,7 +104,7 @@ class _ClassScheduleInquiryPageState extends State<ClassScheduleInquiryPage> {
     }
     try {
       final subjects = await _zhjwApi.fetchSubjectsByDepartment(departmentNum);
-      if (!mounted || seq != _requestSeq) return;
+      if (!mounted || seq != _subjectReqSeq) return;
       setState(() {
         _subjects = subjects;
         _selectedSubject = '';
@@ -114,7 +115,7 @@ class _ClassScheduleInquiryPageState extends State<ClassScheduleInquiryPage> {
   }
 
   Future<void> _loadClassOptions() async {
-    final seq = ++_requestSeq;
+    final seq = ++_classOptionReqSeq;
     if (_selectedGrade.isEmpty || _selectedDepartment.isEmpty) {
       setState(() {
         _classOptions = [];
@@ -128,7 +129,7 @@ class _ClassScheduleInquiryPageState extends State<ClassScheduleInquiryPage> {
         departmentNum: _selectedDepartment,
         subjectNum: _selectedSubject,
       );
-      if (!mounted || seq != _requestSeq) return;
+      if (!mounted || seq != _classOptionReqSeq) return;
       setState(() {
         _classOptions = options;
         _selectedClass = '';

--- a/lib/pages/campus/class_schedule_inquiry/class_schedule_inquiry_page.dart
+++ b/lib/pages/campus/class_schedule_inquiry/class_schedule_inquiry_page.dart
@@ -1,0 +1,535 @@
+import 'package:flutter/material.dart';
+import 'package:bugaoshan/injection/injector.dart';
+import 'package:bugaoshan/l10n/app_localizations.dart';
+import 'package:bugaoshan/pages/campus/class_schedule_inquiry/class_schedule_inquiry_detail_page.dart';
+import 'package:bugaoshan/pages/campus/models/class_schedule_inquiry_model.dart';
+import 'package:bugaoshan/providers/scu_auth_provider.dart';
+import 'package:bugaoshan/services/api/zhjw_api_service.dart';
+import 'package:bugaoshan/services/auth/scu_exceptions.dart';
+import 'package:bugaoshan/widgets/common/loading_widgets.dart';
+import 'package:bugaoshan/widgets/common/login_required_widget.dart';
+
+class ClassScheduleInquiryPage extends StatefulWidget {
+  const ClassScheduleInquiryPage({super.key});
+
+  @override
+  State<ClassScheduleInquiryPage> createState() =>
+      _ClassScheduleInquiryPageState();
+}
+
+class _ClassScheduleInquiryPageState extends State<ClassScheduleInquiryPage> {
+  late final ZhjwApiService _zhjwApi;
+
+  // 班级数据
+  List<ClassInfo> _classes = [];
+  bool _isLoading = false;
+  bool _isLoadingMore = false;
+  bool _hasMore = true;
+  int _pageNum = 1;
+  static const int _pageSize = 30;
+  String? _error;
+
+  // 筛选选项
+  List<SemesterOption> _semesters = [];
+  List<String> _grades = [];
+  List<DepartmentOption> _departments = [];
+  List<SubjectOption> _subjects = [];
+  List<ClassOption> _classOptions = [];
+
+  // 筛选状态
+  bool _isLoadingIndex = true;
+  String _selectedSemester = '';
+  String _selectedGrade = '';
+  String _selectedDepartment = '';
+  String _selectedSubject = '';
+  String _selectedClass = '';
+
+  @override
+  void initState() {
+    super.initState();
+    _zhjwApi = getIt<ZhjwApiService>();
+    getIt<ScuAuthProvider>().addListener(_onAuthChanged);
+    _loadIndex();
+  }
+
+  @override
+  void dispose() {
+    getIt<ScuAuthProvider>().removeListener(_onAuthChanged);
+    super.dispose();
+  }
+
+  void _onAuthChanged() {
+    final auth = getIt<ScuAuthProvider>();
+    if (auth.isLoggedIn && mounted) {
+      _loadIndex();
+    } else if (mounted) {
+      setState(() {});
+    }
+  }
+
+  Future<void> _loadIndex() async {
+    final auth = getIt<ScuAuthProvider>();
+    if (!auth.isLoggedIn) return;
+    setState(() => _isLoadingIndex = true);
+    try {
+      final result = await _zhjwApi.fetchClassScheduleInquiryIndex();
+      if (!mounted) return;
+      setState(() {
+        _semesters = result.semesters;
+        _grades = result.grades;
+        _departments = result.departments;
+        _isLoadingIndex = false;
+      });
+      await _search();
+    } catch (e) {
+      debugPrint('ClassScheduleInquiry index load error: $e');
+      if (!mounted) return;
+      setState(() {
+        _error = 'loadFailed';
+        _isLoadingIndex = false;
+      });
+    }
+  }
+
+  Future<void> _loadSubjects(String departmentNum) async {
+    if (departmentNum.isEmpty) {
+      setState(() {
+        _subjects = [];
+        _selectedSubject = '';
+      });
+      return;
+    }
+    try {
+      final subjects = await _zhjwApi.fetchSubjectsByDepartment(departmentNum);
+      if (!mounted) return;
+      setState(() {
+        _subjects = subjects;
+        _selectedSubject = '';
+      });
+    } catch (e) {
+      debugPrint('Load subjects error: $e');
+    }
+  }
+
+  Future<void> _loadClassOptions() async {
+    if (_selectedGrade.isEmpty || _selectedDepartment.isEmpty) {
+      setState(() {
+        _classOptions = [];
+        _selectedClass = '';
+      });
+      return;
+    }
+    try {
+      final options = await _zhjwApi.fetchClassOptions(
+        yearNum: _selectedGrade,
+        departmentNum: _selectedDepartment,
+        subjectNum: _selectedSubject,
+      );
+      if (!mounted) return;
+      setState(() {
+        _classOptions = options;
+        _selectedClass = '';
+      });
+    } catch (e) {
+      debugPrint('Load class options error: $e');
+    }
+  }
+
+  Future<void> _search() async {
+    setState(() {
+      _pageNum = 1;
+      _classes = [];
+      _hasMore = true;
+      _error = null;
+    });
+    await _loadClasses();
+  }
+
+  Future<void> _refresh() async {
+    await _search();
+  }
+
+  Future<void> _loadClasses() async {
+    final auth = getIt<ScuAuthProvider>();
+    if (!auth.isLoggedIn) return;
+
+    if (_pageNum == 1) {
+      setState(() {
+        _isLoading = true;
+        _error = null;
+      });
+    } else {
+      setState(() => _isLoadingMore = true);
+    }
+
+    try {
+      final result = await _zhjwApi.fetchClassList(
+        pageNum: _pageNum,
+        pageSize: _pageSize,
+        executiveEducationPlanNum: _selectedSemester,
+        yearNum: _selectedGrade,
+        departmentNum: _selectedDepartment,
+        subjectNum: _selectedSubject,
+        classNum: _selectedClass,
+      );
+      if (!mounted) return;
+      setState(() {
+        _classes.addAll(result.classes);
+        _hasMore = _classes.length < result.totalCount;
+        _isLoading = false;
+        _isLoadingMore = false;
+      });
+    } on UnauthenticatedException catch (_) {
+      if (!mounted) return;
+      setState(() {
+        _error = 'sessionExpired';
+        _isLoading = false;
+        _isLoadingMore = false;
+      });
+    } catch (e) {
+      debugPrint('ClassScheduleInquiry load error: $e');
+      if (!mounted) return;
+      setState(() {
+        _error = 'loadFailed';
+        _isLoading = false;
+        _isLoadingMore = false;
+      });
+    }
+  }
+
+  void _loadMore() {
+    if (_isLoadingMore || !_hasMore) return;
+    _pageNum++;
+    _loadClasses();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    return Scaffold(
+      appBar: AppBar(title: Text(l10n.classScheduleInquiry)),
+      body: ListenableBuilder(
+        listenable: getIt<ScuAuthProvider>(),
+        builder: (context, _) {
+          final auth = getIt<ScuAuthProvider>();
+          if (!auth.isLoggedIn) {
+            if (auth.isAutoLoggingIn) return const AutoLoginLoadingWidget();
+            return const LoginRequiredWidget();
+          }
+          return _buildContent(context);
+        },
+      ),
+    );
+  }
+
+  Widget _buildContent(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+
+    if (_isLoadingIndex) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (_error != null && _classes.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(
+              _error == 'sessionExpired'
+                  ? l10n.sessionExpired
+                  : l10n.loadFailed,
+              style: Theme.of(context).textTheme.bodyLarge,
+            ),
+            const SizedBox(height: 16),
+            FilledButton(onPressed: _loadIndex, child: Text(l10n.retry)),
+          ],
+        ),
+      );
+    }
+
+    return Column(
+      children: [
+        _buildFilterBar(context),
+        Expanded(child: _buildClassList(context)),
+      ],
+    );
+  }
+
+  Widget _buildFilterBar(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final theme = Theme.of(context);
+
+    return Card(
+      margin: const EdgeInsets.fromLTRB(12, 12, 12, 0),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              l10n.classScheduleInquiryFilter,
+              style: theme.textTheme.titleSmall?.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                Expanded(
+                  child: _buildDropdown(
+                    value: _selectedSemester,
+                    items: _semesters
+                        .map(
+                          (s) => DropdownMenuItem(
+                            value: s.value,
+                            child: Text(
+                              s.label,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                        )
+                        .toList(),
+                    onChanged: (v) => setState(() => _selectedSemester = v),
+                    hint: l10n.classScheduleInquirySemester,
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: _buildDropdown(
+                    value: _selectedGrade,
+                    items: _grades
+                        .map(
+                          (g) => DropdownMenuItem(
+                            value: g,
+                            child: Text('$g级', overflow: TextOverflow.ellipsis),
+                          ),
+                        )
+                        .toList(),
+                    onChanged: (v) {
+                      setState(() => _selectedGrade = v);
+                      _loadClassOptions();
+                    },
+                    hint: l10n.classScheduleInquiryGrade,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                Expanded(
+                  child: _buildDropdown(
+                    value: _selectedDepartment,
+                    items: _departments
+                        .map(
+                          (d) => DropdownMenuItem(
+                            value: d.value,
+                            child: Text(
+                              d.name,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                        )
+                        .toList(),
+                    onChanged: (v) {
+                      setState(() {
+                        _selectedDepartment = v;
+                        _selectedSubject = '';
+                        _subjects = [];
+                      });
+                      _loadSubjects(v);
+                      _loadClassOptions();
+                    },
+                    hint: l10n.classScheduleInquiryDepartment,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                Expanded(
+                  child: _buildDropdown(
+                    value: _selectedSubject,
+                    items: [
+                      const DropdownMenuItem(value: '', child: Text('全部')),
+                      ..._subjects.map(
+                        (s) => DropdownMenuItem(
+                          value: s.code,
+                          child: Text(s.name, overflow: TextOverflow.ellipsis),
+                        ),
+                      ),
+                    ],
+                    onChanged: (v) {
+                      setState(() => _selectedSubject = v);
+                      _loadClassOptions();
+                    },
+                    hint: l10n.classScheduleInquirySubject,
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: _buildDropdown(
+                    value: _selectedClass,
+                    items: [
+                      const DropdownMenuItem(value: '', child: Text('全部')),
+                      ..._classOptions.map(
+                        (c) => DropdownMenuItem(
+                          value: c.code,
+                          child: Text(c.name, overflow: TextOverflow.ellipsis),
+                        ),
+                      ),
+                    ],
+                    onChanged: (v) => setState(() => _selectedClass = v),
+                    hint: l10n.classScheduleInquiryClass,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton.icon(
+                onPressed: _search,
+                icon: const Icon(Icons.search),
+                label: Text(l10n.classScheduleInquirySearch),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDropdown({
+    required String value,
+    required List<DropdownMenuItem<String>> items,
+    required ValueChanged<String> onChanged,
+    required String hint,
+  }) {
+    return DropdownButtonFormField<String>(
+      key: ValueKey('dropdown_$value'),
+      initialValue: value.isEmpty && items.any((i) => i.value == '')
+          ? ''
+          : (value.isEmpty ? null : value),
+      decoration: const InputDecoration(
+        contentPadding: EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        border: OutlineInputBorder(),
+        isDense: true,
+      ),
+      isExpanded: true,
+      hint: Text(hint, style: const TextStyle(fontSize: 13)),
+      items: items,
+      onChanged: (v) {
+        if (v != null) onChanged(v);
+      },
+    );
+  }
+
+  Widget _buildClassList(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+
+    if (_isLoading) return const Center(child: CircularProgressIndicator());
+
+    if (_classes.isEmpty) {
+      return Center(
+        child: Text(
+          l10n.classScheduleInquiryNoData,
+          style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+            color: Theme.of(context).colorScheme.onSurfaceVariant,
+          ),
+        ),
+      );
+    }
+
+    return RefreshIndicator(
+      onRefresh: _refresh,
+      child: ListView.builder(
+        padding: const EdgeInsets.all(12),
+        itemCount: _classes.length + (_hasMore ? 1 : 0),
+        itemBuilder: (context, index) {
+          if (index == _classes.length) {
+            return Padding(
+              padding: const EdgeInsets.all(16),
+              child: Center(
+                child: _isLoadingMore
+                    ? const CircularProgressIndicator()
+                    : FilledButton.tonal(
+                        onPressed: _loadMore,
+                        child: Text(l10n.classScheduleInquiryLoadMore),
+                      ),
+              ),
+            );
+          }
+          final classInfo = _classes[index];
+          return _ClassCard(
+            classInfo: classInfo,
+            onTap: () => Navigator.of(context).push(
+              MaterialPageRoute(
+                builder: (_) =>
+                    ClassScheduleInquiryDetailPage(classInfo: classInfo),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _ClassCard extends StatelessWidget {
+  final ClassInfo classInfo;
+  final VoidCallback onTap;
+
+  const _ClassCard({required this.classInfo, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.only(bottom: 8),
+      child: ListTile(
+        onTap: onTap,
+        leading: CircleAvatar(
+          backgroundColor: Theme.of(context).colorScheme.primaryContainer,
+          child: Text(
+            classInfo.className.length >= 4
+                ? classInfo.className.substring(classInfo.className.length - 4)
+                : classInfo.className,
+            style: TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+              color: Theme.of(context).colorScheme.onPrimaryContainer,
+            ),
+          ),
+        ),
+        title: Text(
+          classInfo.className,
+          style: Theme.of(
+            context,
+          ).textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w600),
+        ),
+        subtitle: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const SizedBox(height: 4),
+            Text(
+              classInfo.subjectName,
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+            if (classInfo.departmentName.isNotEmpty)
+              Text(
+                classInfo.departmentName,
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+              ),
+          ],
+        ),
+        trailing: Icon(
+          Icons.chevron_right,
+          color: Theme.of(context).colorScheme.onSurfaceVariant,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/campus/class_schedule_inquiry/class_schedule_inquiry_page.dart
+++ b/lib/pages/campus/class_schedule_inquiry/class_schedule_inquiry_page.dart
@@ -27,6 +27,7 @@ class _ClassScheduleInquiryPageState extends State<ClassScheduleInquiryPage> {
   bool _hasMore = true;
   int _pageNum = 1;
   static const int _pageSize = 30;
+  int _requestSeq = 0;
   String? _error;
 
   // 筛选选项
@@ -92,6 +93,7 @@ class _ClassScheduleInquiryPageState extends State<ClassScheduleInquiryPage> {
   }
 
   Future<void> _loadSubjects(String departmentNum) async {
+    final seq = ++_requestSeq;
     if (departmentNum.isEmpty) {
       setState(() {
         _subjects = [];
@@ -101,7 +103,7 @@ class _ClassScheduleInquiryPageState extends State<ClassScheduleInquiryPage> {
     }
     try {
       final subjects = await _zhjwApi.fetchSubjectsByDepartment(departmentNum);
-      if (!mounted) return;
+      if (!mounted || seq != _requestSeq) return;
       setState(() {
         _subjects = subjects;
         _selectedSubject = '';
@@ -112,6 +114,7 @@ class _ClassScheduleInquiryPageState extends State<ClassScheduleInquiryPage> {
   }
 
   Future<void> _loadClassOptions() async {
+    final seq = ++_requestSeq;
     if (_selectedGrade.isEmpty || _selectedDepartment.isEmpty) {
       setState(() {
         _classOptions = [];
@@ -125,7 +128,7 @@ class _ClassScheduleInquiryPageState extends State<ClassScheduleInquiryPage> {
         departmentNum: _selectedDepartment,
         subjectNum: _selectedSubject,
       );
-      if (!mounted) return;
+      if (!mounted || seq != _requestSeq) return;
       setState(() {
         _classOptions = options;
         _selectedClass = '';
@@ -307,7 +310,7 @@ class _ClassScheduleInquiryPageState extends State<ClassScheduleInquiryPage> {
                         .toList(),
                     onChanged: (v) {
                       setState(() => _selectedGrade = v);
-                      _loadClassOptions();
+                      if (_selectedDepartment.isNotEmpty) _loadClassOptions();
                     },
                     hint: l10n.classScheduleInquiryGrade,
                   ),
@@ -407,11 +410,11 @@ class _ClassScheduleInquiryPageState extends State<ClassScheduleInquiryPage> {
     required ValueChanged<String> onChanged,
     required String hint,
   }) {
+    final hasEmptyOption = items.any((i) => i.value == '');
+    final initialValue = value.isEmpty ? (hasEmptyOption ? '' : null) : value;
     return DropdownButtonFormField<String>(
       key: ValueKey('dropdown_$value'),
-      initialValue: value.isEmpty && items.any((i) => i.value == '')
-          ? ''
-          : (value.isEmpty ? null : value),
+      initialValue: initialValue,
       decoration: const InputDecoration(
         contentPadding: EdgeInsets.symmetric(horizontal: 8, vertical: 4),
         border: OutlineInputBorder(),

--- a/lib/pages/campus/models/class_schedule_inquiry_model.dart
+++ b/lib/pages/campus/models/class_schedule_inquiry_model.dart
@@ -1,0 +1,121 @@
+/// 班级课表 - 班级列表中的一个班级
+class ClassInfo {
+  final String planCode; // executiveEducationPlanNumber
+  final String classCode; // classNum
+  final String planName; // executiveEducationPlanName
+  final String className; // className
+  final String departmentName;
+  final String subjectName;
+
+  ClassInfo({
+    required this.planCode,
+    required this.classCode,
+    required this.planName,
+    required this.className,
+    required this.departmentName,
+    required this.subjectName,
+  });
+
+  factory ClassInfo.fromJson(Map<String, dynamic> json) {
+    final id = json['id'] as Map<String, dynamic>;
+    return ClassInfo(
+      planCode: id['executiveEducationPlanNumber'] as String? ?? '',
+      classCode: id['classNum'] as String? ?? '',
+      planName: json['executiveEducationPlanName'] as String? ?? '',
+      className: json['className'] as String? ?? '',
+      departmentName: json['departmentName'] as String? ?? '',
+      subjectName: json['subjectName'] as String? ?? '',
+    );
+  }
+}
+
+/// 学年学期筛选选项
+class SemesterOption {
+  final String value; // e.g. "2026-2027-1-1"
+  final String label; // e.g. "2026-2027学年秋"
+
+  SemesterOption({required this.value, required this.label});
+
+  factory SemesterOption.fromSelectOption(String value, String label) =>
+      SemesterOption(value: value, label: label);
+}
+
+/// 院系筛选选项
+class DepartmentOption {
+  final String value; // e.g. "201"
+  final String name; // e.g. "数学学院"
+
+  DepartmentOption({required this.value, required this.name});
+}
+
+/// 专业筛选选项
+class SubjectOption {
+  final String code; // e.g. "0701018"
+  final String name; // e.g. "数学与智能科技双学士学位"
+
+  SubjectOption({required this.code, required this.name});
+
+  factory SubjectOption.fromJson(Map<String, dynamic> json) => SubjectOption(
+    code: json['subjectCode'] as String? ?? '',
+    name: json['subjectName'] as String? ?? '',
+  );
+}
+
+/// 班级筛选选项
+class ClassOption {
+  final String code; // e.g. "242010801"
+  final String name; // e.g. "242010801"
+
+  ClassOption({required this.code, required this.name});
+
+  factory ClassOption.fromJson(Map<String, dynamic> json) => ClassOption(
+    code: json['classCode'] as String? ?? '',
+    name: json['className'] as String? ?? '',
+  );
+}
+
+/// 班级课表 - 课表中的一门课程
+class ClassScheduleInquiryItem {
+  final int dayOfWeek; // skxq: 1-7 (星期一~星期日)
+  final int startPeriod; // skjc: 开始节次
+  final int duration; // cxjc: 持续节数
+  final String courseCode; // kch: 课程号
+  final String courseSeq; // kxh: 课序号
+  final String courseName; // kcm: 课程名
+  final String teacherName; // jsm: 教师名
+  final String weeksDescription; // zcsm: 周次说明
+  final String campus; // xqm: 校区
+  final String building; // jxlm: 教学楼
+  final String classroom; // jasm: 教室
+
+  ClassScheduleInquiryItem({
+    required this.dayOfWeek,
+    required this.startPeriod,
+    required this.duration,
+    required this.courseCode,
+    required this.courseSeq,
+    required this.courseName,
+    required this.teacherName,
+    required this.weeksDescription,
+    required this.campus,
+    required this.building,
+    required this.classroom,
+  });
+
+  factory ClassScheduleInquiryItem.fromJson(Map<String, dynamic> json) {
+    final id = json['id'] as Map<String, dynamic>;
+    return ClassScheduleInquiryItem(
+      dayOfWeek: int.tryParse(id['skxq']?.toString() ?? '') ?? 0,
+      startPeriod: int.tryParse(id['skjc']?.toString() ?? '') ?? 0,
+      duration: int.tryParse(json['cxjc']?.toString() ?? '') ?? 0,
+      courseCode: id['kch'] as String? ?? '',
+      courseSeq: id['kxh'] as String? ?? '',
+      courseName: json['kcm'] as String? ?? '',
+      teacherName: json['jsm'] as String? ?? '',
+      weeksDescription: json['zcsm'] as String? ?? '',
+      campus: json['xqm'] as String? ?? '',
+      building: json['jxlm'] as String? ?? '',
+      classroom: json['jasm'] as String? ?? '',
+    );
+  }
+}

--- a/lib/services/api/zhjw_api_service.dart
+++ b/lib/services/api/zhjw_api_service.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:bugaoshan/pages/campus/models/class_schedule_inquiry_model.dart';
 import 'package:bugaoshan/pages/campus/models/classroom_model.dart';
 import 'package:bugaoshan/pages/campus/plan_completion/models/plan_completion.dart';
 import 'package:bugaoshan/pages/campus/train_program/models/train_program.dart';
@@ -489,8 +490,222 @@ class ZhjwApiService {
   }
 
   // ═══════════════════════════════════════════════════════════════════
+  //  班级课表
+  // ═══════════════════════════════════════════════════════════════════
+
+  /// 获取班级课表首页的筛选选项
+  Future<
+    ({
+      List<SemesterOption> semesters,
+      List<String> grades,
+      List<DepartmentOption> departments,
+    })
+  >
+  fetchClassScheduleInquiryIndex() {
+    return _request((client) async {
+      final resp = await client.get(
+        Uri.parse('$kZhjwBase/student/teachingResources/classCurriculum/index'),
+        headers: {
+          'Accept': 'text/html,*/*',
+          'Referer': '$kZhjwBase/',
+          'User-Agent': kDefaultUserAgent,
+        },
+      );
+      final body = resp.body.trim();
+      _checkSessionExpiry(body, resp.statusCode);
+
+      // 解析学年学期
+      final semesterOptions = _parseSelectOptions(
+        body,
+        'executiveEducationPlanNum',
+      );
+      final semesters = semesterOptions
+          .where((o) => o.value.isNotEmpty)
+          .map((o) => SemesterOption(value: o.value, label: o.label))
+          .toList();
+
+      // 解析年级
+      final gradeOptions = _parseSelectOptions(body, 'yearNum');
+      final grades = gradeOptions
+          .where((o) => o.value.isNotEmpty)
+          .map((o) => o.value)
+          .toList();
+
+      // 解析院系
+      final deptOptions = _parseSelectOptions(body, 'departmentNum');
+      final departments = deptOptions
+          .where((o) => o.value.isNotEmpty)
+          .map((o) => DepartmentOption(value: o.value, name: o.label))
+          .toList();
+
+      return (semesters: semesters, grades: grades, departments: departments);
+    });
+  }
+
+  /// 根据院系获取专业列表
+  Future<List<SubjectOption>> fetchSubjectsByDepartment(String departmentNum) {
+    return _request((client) async {
+      final resp = await client.get(
+        Uri.parse(
+          '$kZhjwBase/student/teachingResources/gradeAndClassCurriculum/subjectJson'
+          '?departmentNum=${Uri.encodeComponent(departmentNum)}',
+        ),
+        headers: {
+          'Accept': 'application/json, text/javascript, */*; q=0.01',
+          'Referer':
+              '$kZhjwBase/student/teachingResources/classCurriculum/index',
+          'User-Agent': kDefaultUserAgent,
+          'X-Requested-With': 'XMLHttpRequest',
+        },
+      );
+      final body = resp.body.trim();
+      _checkSessionExpiry(body, resp.statusCode);
+      final list = jsonDecode(body) as List<dynamic>;
+      return list
+          .map((e) => SubjectOption.fromJson(e as Map<String, dynamic>))
+          .toList();
+    });
+  }
+
+  /// 根据年级、院系、专业获取班级列表
+  Future<List<ClassOption>> fetchClassOptions({
+    required String yearNum,
+    required String departmentNum,
+    String subjectNum = '',
+  }) {
+    return _request((client) async {
+      final resp = await client.get(
+        Uri.parse(
+          '$kZhjwBase/student/teachingResources/gradeAndClassCurriculum/classJson'
+          '?departmentNum=${Uri.encodeComponent(departmentNum)}'
+          '&subjectNum=${Uri.encodeComponent(subjectNum)}'
+          '&yearNum=${Uri.encodeComponent(yearNum)}',
+        ),
+        headers: {
+          'Accept': 'application/json, text/javascript, */*; q=0.01',
+          'Referer':
+              '$kZhjwBase/student/teachingResources/classCurriculum/index',
+          'User-Agent': kDefaultUserAgent,
+          'X-Requested-With': 'XMLHttpRequest',
+        },
+      );
+      final body = resp.body.trim();
+      _checkSessionExpiry(body, resp.statusCode);
+      final list = jsonDecode(body) as List<dynamic>;
+      return list
+          .map((e) => ClassOption.fromJson(e as Map<String, dynamic>))
+          .toList();
+    });
+  }
+
+  /// 搜索班级列表（支持筛选）
+  Future<({List<ClassInfo> classes, int totalCount})> fetchClassList({
+    int pageNum = 1,
+    int pageSize = 30,
+    String executiveEducationPlanNum = '',
+    String yearNum = '',
+    String departmentNum = '',
+    String subjectNum = '',
+    String classNum = '',
+  }) {
+    return _request((client) async {
+      final resp = await client.post(
+        Uri.parse(
+          '$kZhjwBase/student/teachingResources/classCurriculum/search',
+        ),
+        headers: {
+          'Accept': 'application/json, text/javascript, */*; q=0.01',
+          'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+          'Referer':
+              '$kZhjwBase/student/teachingResources/classCurriculum/index',
+          'User-Agent': kDefaultUserAgent,
+          'X-Requested-With': 'XMLHttpRequest',
+        },
+        body:
+            'executiveEducationPlanNum=${Uri.encodeComponent(executiveEducationPlanNum)}'
+            '&yearNum=${Uri.encodeComponent(yearNum)}'
+            '&departmentNum=${Uri.encodeComponent(departmentNum)}'
+            '&subjectNum=${Uri.encodeComponent(subjectNum)}'
+            '&classNum=${Uri.encodeComponent(classNum)}'
+            '&pageNum=$pageNum&pageSize=$pageSize',
+      );
+      final body = resp.body.trim();
+      _checkSessionExpiry(body, resp.statusCode);
+      final json = jsonDecode(body) as List<dynamic>;
+      final first = json.isNotEmpty
+          ? json[0] as Map<String, dynamic>
+          : <String, dynamic>{};
+      final records = (first['records'] as List<dynamic>?) ?? [];
+      final totalCount =
+          (first['pageContext']?['totalCount'] as num?)?.toInt() ?? 0;
+      final classes = records
+          .map((e) => ClassInfo.fromJson(e as Map<String, dynamic>))
+          .toList();
+      return (classes: classes, totalCount: totalCount);
+    });
+  }
+
+  /// 获取指定班级的课表
+  Future<List<ClassScheduleInquiryItem>> fetchClassSchedule({
+    required String planCode,
+    required String classCode,
+  }) {
+    return _request((client) async {
+      final resp = await client.get(
+        Uri.parse(
+          '$kZhjwBase/student/teachingResources/classCurriculum/searchCurriculumInfo/callback'
+          '?planCode=${Uri.encodeComponent(planCode)}'
+          '&classCode=${Uri.encodeComponent(classCode)}',
+        ),
+        headers: {
+          'Accept': 'application/json, text/javascript, */*; q=0.01',
+          'Referer':
+              '$kZhjwBase/student/teachingResources/classCurriculum/index',
+          'User-Agent': kDefaultUserAgent,
+          'X-Requested-With': 'XMLHttpRequest',
+        },
+      );
+      final body = resp.body.trim();
+      _checkSessionExpiry(body, resp.statusCode);
+      final json = jsonDecode(body) as List<dynamic>;
+      final list = (json.isNotEmpty ? json[0] : []) as List<dynamic>;
+      return list
+          .map(
+            (e) => ClassScheduleInquiryItem.fromJson(e as Map<String, dynamic>),
+          )
+          .toList();
+    });
+  }
+
+  // ═══════════════════════════════════════════════════════════════════
   //  HTML 解析工具
   // ═══════════════════════════════════════════════════════════════════
+
+  /// 从 HTML 中解析 select 元素的选项列表
+  List<({String value, String label})> _parseSelectOptions(
+    String html,
+    String selectId,
+  ) {
+    final selectRegex = RegExp(
+      '''<select[^>]*name="$selectId"[^>]*>([\\s\\S]*?)</select>''',
+    );
+    final match = selectRegex.firstMatch(html);
+    if (match == null) return [];
+
+    final optionsRegex = RegExp(
+      '''<option[^>]*value="([^"]*)"[^>]*>([\\s\\S]*?)</option>''',
+    );
+    final options = optionsRegex.allMatches(match.group(1)!);
+    return options
+        .where((m) => m.group(1)!.isNotEmpty)
+        .map(
+          (m) => (
+            value: m.group(1)!,
+            label: m.group(2)!.replaceAll(RegExp(r'<[^>]+>'), '').trim(),
+          ),
+        )
+        .toList();
+  }
 
   List<College> _parseOptions(String html, String selectId) {
     final selectRegex = RegExp(
@@ -500,7 +715,7 @@ class ZhjwApiService {
     if (match == null) return [];
 
     final optionsRegex = RegExp(
-      '''<option[^>]*value="([^"]*)"[^>]*>(.*?)</option>''',
+      '''<option[^>]*value="([^"]*)"[^>]*>([\\s\\S]*?)</option>''',
     );
     final options = optionsRegex.allMatches(match.group(1)!);
     return options
@@ -522,7 +737,7 @@ class ZhjwApiService {
     if (match == null) return [];
 
     final optionsRegex = RegExp(
-      '''<option[^>]*value="([^"]*)"[^>]*>(.*?)</option>''',
+      '''<option[^>]*value="([^"]*)"[^>]*>([\\s\\S]*?)</option>''',
     );
     final options = optionsRegex.allMatches(match.group(1)!);
     return options

--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -15,6 +15,7 @@ const String dockIdAcademicCalendar = 'academic_calendar';
 const String dockIdFitnessTest = 'fitness_test';
 const String dockIdNotice = 'notice';
 const String dockIdDownloadedAttachments = 'downloaded_attachments';
+const String dockIdClassScheduleInquiry = 'class_schedule_inquiry';
 
 const Duration kHttpTimeout = Duration(seconds: 15);
 

--- a/lib/utils/week_parser.dart
+++ b/lib/utils/week_parser.dart
@@ -1,0 +1,41 @@
+import 'package:bugaoshan/models/course.dart';
+
+/// Parses a week description string from the academic affairs system
+/// into (startWeek, endWeek, weekType).
+///
+/// zcsm formats:
+///   "1-10周"      → (1, 10, every)
+///   "1-10,12周"   → (1, 12, every)  (week 12 is standalone)
+///   "1-16(单)"    → (1, 16, odd)
+///   "第16周"      → (16, 16, every)
+///   "1-16(双)"    → (1, 16, even)
+(int startWeek, int endWeek, WeekType weekType) parseWeeks(String zcsm) {
+  if (zcsm.isEmpty) return (1, 20, WeekType.every);
+  final text = zcsm.replaceAll('周', '').trim();
+  WeekType weekType = WeekType.every;
+  if (text.contains('单')) weekType = WeekType.odd;
+  if (text.contains('双')) weekType = WeekType.even;
+  final numbers = text.replaceAll(RegExp(r'[^\d,\-]'), '');
+  if (numbers.isEmpty) return (1, 20, weekType);
+  final parts = numbers.split(',');
+  int? minStart;
+  int? maxEnd;
+  for (final part in parts) {
+    final range = part.split('-');
+    if (range.length == 2) {
+      final s = int.tryParse(range[0]);
+      final e = int.tryParse(range[1]);
+      if (s != null && e != null) {
+        minStart = minStart == null ? s : (s < minStart ? s : minStart);
+        maxEnd = maxEnd == null ? e : (e > maxEnd ? e : maxEnd);
+      }
+    } else if (range.length == 1) {
+      final w = int.tryParse(range[0]);
+      if (w != null) {
+        minStart = minStart == null ? w : (w < minStart ? w : minStart);
+        maxEnd = maxEnd == null ? w : (w > maxEnd ? w : maxEnd);
+      }
+    }
+  }
+  return (minStart ?? 1, maxEnd ?? 20, weekType);
+}

--- a/lib/widgets/course/course_card.dart
+++ b/lib/widgets/course/course_card.dart
@@ -44,16 +44,22 @@ class CourseCard extends StatelessWidget {
             : Colors.white;
         final fontSize = appConfig.courseCardFontSize.value;
         final smallFontSize = fontSize - 1;
-        final details = <({String text, int preferredMaxLines})>[
-          if (config.showLocation && course.location.isNotEmpty)
-            (text: course.location, preferredMaxLines: 2),
-          if (config.showTeacherName && course.teacher.isNotEmpty)
-            (text: course.teacher, preferredMaxLines: 2),
-          (
-            text: l10n.weekRange(course.startWeek, course.endWeek),
-            preferredMaxLines: 1,
-          ),
-        ];
+        final details =
+            <({String text, int preferredMaxLines, int renderMaxLines})>[
+              if (config.showLocation && course.location.isNotEmpty)
+                (
+                  text: course.location,
+                  preferredMaxLines: 2,
+                  renderMaxLines: 2,
+                ),
+              if (config.showTeacherName && course.teacher.isNotEmpty)
+                (text: course.teacher, preferredMaxLines: 2, renderMaxLines: 2),
+              (
+                text: l10n.weekRange(course.startWeek, course.endWeek),
+                preferredMaxLines: 1,
+                renderMaxLines: 2,
+              ),
+            ];
 
         return GestureDetector(
           onTap: onTap,
@@ -66,7 +72,10 @@ class CourseCard extends StatelessWidget {
                 < 100 => 3,
                 _ => 5,
               };
-              final visibleDetails = <({String text, int preferredMaxLines})>[];
+              final visibleDetails =
+                  <
+                    ({String text, int preferredMaxLines, int renderMaxLines})
+                  >[];
               var usedDetailLines = 0;
               for (final detail in details) {
                 final nextUsedLines =
@@ -117,7 +126,7 @@ class CourseCard extends StatelessWidget {
                               detail.text,
                               smallFontSize,
                               textColor,
-                              maxLines: detail.preferredMaxLines,
+                              maxLines: detail.renderMaxLines,
                             ),
                           ),
                         ],

--- a/lib/widgets/course/course_card.dart
+++ b/lib/widgets/course/course_card.dart
@@ -8,6 +8,7 @@ class CourseCard extends StatelessWidget {
   final Course course;
   final ScheduleConfig config;
   final int displayWeek;
+  final bool forceActive;
   final VoidCallback? onTap;
   final VoidCallback? onLongPress;
 
@@ -16,6 +17,7 @@ class CourseCard extends StatelessWidget {
     required this.course,
     required this.config,
     required this.displayWeek,
+    this.forceActive = false,
     this.onTap,
     this.onLongPress,
   });
@@ -31,7 +33,7 @@ class CourseCard extends StatelessWidget {
         appConfig.courseCardFontSize,
       ]),
       builder: (context, _) {
-        final isActive = course.isActiveInWeek(displayWeek);
+        final isActive = forceActive || course.isActiveInWeek(displayWeek);
         final color = isActive
             ? course.color.withValues(alpha: appConfig.colorOpacity.value)
             : _greyscale(course.color).withValues(alpha: 0.12);

--- a/lib/widgets/course/course_card.dart
+++ b/lib/widgets/course/course_card.dart
@@ -48,7 +48,7 @@ class CourseCard extends StatelessWidget {
           if (config.showLocation && course.location.isNotEmpty)
             (text: course.location, preferredMaxLines: 2),
           if (config.showTeacherName && course.teacher.isNotEmpty)
-            (text: course.teacher, preferredMaxLines: 1),
+            (text: course.teacher, preferredMaxLines: 2),
           (
             text: l10n.weekRange(course.startWeek, course.endWeek),
             preferredMaxLines: 2,

--- a/lib/widgets/course/course_card.dart
+++ b/lib/widgets/course/course_card.dart
@@ -8,7 +8,7 @@ class CourseCard extends StatelessWidget {
   final Course course;
   final ScheduleConfig config;
   final int displayWeek;
-  final bool forceActive;
+  final bool showAllWeeks;
   final VoidCallback? onTap;
   final VoidCallback? onLongPress;
 
@@ -17,7 +17,7 @@ class CourseCard extends StatelessWidget {
     required this.course,
     required this.config,
     required this.displayWeek,
-    this.forceActive = false,
+    this.showAllWeeks = false,
     this.onTap,
     this.onLongPress,
   });
@@ -33,7 +33,7 @@ class CourseCard extends StatelessWidget {
         appConfig.courseCardFontSize,
       ]),
       builder: (context, _) {
-        final isActive = forceActive || course.isActiveInWeek(displayWeek);
+        final isActive = showAllWeeks || course.isActiveInWeek(displayWeek);
         final color = isActive
             ? course.color.withValues(alpha: appConfig.colorOpacity.value)
             : _greyscale(course.color).withValues(alpha: 0.12);

--- a/lib/widgets/course/course_card.dart
+++ b/lib/widgets/course/course_card.dart
@@ -57,7 +57,7 @@ class CourseCard extends StatelessWidget {
               (
                 text: l10n.weekRange(course.startWeek, course.endWeek),
                 preferredMaxLines: 1,
-                renderMaxLines: 2,
+                renderMaxLines: 4,
               ),
             ];
 
@@ -102,34 +102,39 @@ class CourseCard extends StatelessWidget {
                   ),
                   padding: const EdgeInsets.all(4),
                   child: SizedBox.expand(
-                    child: SingleChildScrollView(
-                      physics: const NeverScrollableScrollPhysics(),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            isActive
-                                ? course.name
-                                : '${l10n.notThisWeek} ${course.name}',
-                            maxLines: titleMaxLines,
-                            style: TextStyle(
-                              fontSize: fontSize,
-                              color: textColor,
-                              height: 1.1,
-                              fontWeight: FontWeight.bold,
+                    child: ScrollConfiguration(
+                      behavior: ScrollConfiguration.of(
+                        context,
+                      ).copyWith(scrollbars: false),
+                      child: SingleChildScrollView(
+                        physics: const NeverScrollableScrollPhysics(),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              isActive
+                                  ? course.name
+                                  : '${l10n.notThisWeek} ${course.name}',
+                              maxLines: titleMaxLines,
+                              style: TextStyle(
+                                fontSize: fontSize,
+                                color: textColor,
+                                height: 1.1,
+                                fontWeight: FontWeight.bold,
+                              ),
                             ),
-                          ),
-                          if (visibleDetails.isNotEmpty)
-                            const SizedBox(height: 2),
-                          ...visibleDetails.map(
-                            (detail) => _buildIconText(
-                              detail.text,
-                              smallFontSize,
-                              textColor,
-                              maxLines: detail.renderMaxLines,
+                            if (visibleDetails.isNotEmpty)
+                              const SizedBox(height: 2),
+                            ...visibleDetails.map(
+                              (detail) => _buildIconText(
+                                detail.text,
+                                smallFontSize,
+                                textColor,
+                                maxLines: detail.renderMaxLines,
+                              ),
                             ),
-                          ),
-                        ],
+                          ],
+                        ),
                       ),
                     ),
                   ),

--- a/lib/widgets/course/course_card.dart
+++ b/lib/widgets/course/course_card.dart
@@ -51,7 +51,7 @@ class CourseCard extends StatelessWidget {
             (text: course.teacher, preferredMaxLines: 2),
           (
             text: l10n.weekRange(course.startWeek, course.endWeek),
-            preferredMaxLines: 2,
+            preferredMaxLines: 1,
           ),
         ];
 

--- a/lib/widgets/course/course_detail_sheet.dart
+++ b/lib/widgets/course/course_detail_sheet.dart
@@ -8,12 +8,12 @@ import 'package:bugaoshan/widgets/route/router_utils.dart';
 
 class CourseDetailSheet extends StatelessWidget {
   final Course course;
-  final CourseProvider courseProvider;
+  final CourseProvider? courseProvider;
 
   const CourseDetailSheet({
     super.key,
     required this.course,
-    required this.courseProvider,
+    this.courseProvider,
   });
 
   String _formatTimeOfDay(TimeOfDay time) {
@@ -23,7 +23,9 @@ class CourseDetailSheet extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
-    final config = courseProvider.scheduleConfig.value;
+    final config =
+        courseProvider?.scheduleConfig.value ??
+        ScheduleConfig(semesterStartDate: DateTime(2025, 9, 1));
 
     String timeRange = '';
     if (course.startSection > 0 &&
@@ -57,70 +59,72 @@ class CourseDetailSheet extends StatelessWidget {
                       ),
                     ),
                   ),
-                  IconButton(
-                    iconSize: 22,
-                    icon: Icon(
-                      Icons.delete_outline,
-                      color: Theme.of(context).colorScheme.error,
-                    ),
-                    style: IconButton.styleFrom(
-                      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                    ),
-                    onPressed: () async {
-                      final confirm = await showYesNoDialog(
-                        title: l10n.deleteCourse,
-                        content: l10n.deleteCourseConfirm,
-                      );
-                      if (confirm == true) {
-                        await courseProvider.deleteCourse(course.id);
-                        if (context.mounted) {
-                          Navigator.pop(context);
+                  if (courseProvider != null) ...[
+                    IconButton(
+                      iconSize: 22,
+                      icon: Icon(
+                        Icons.delete_outline,
+                        color: Theme.of(context).colorScheme.error,
+                      ),
+                      style: IconButton.styleFrom(
+                        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                      ),
+                      onPressed: () async {
+                        final confirm = await showYesNoDialog(
+                          title: l10n.deleteCourse,
+                          content: l10n.deleteCourseConfirm,
+                        );
+                        if (confirm == true) {
+                          await courseProvider?.deleteCourse(course.id);
+                          if (context.mounted) {
+                            Navigator.pop(context);
+                          }
                         }
-                      }
-                    },
-                  ),
-                  IconButton(
-                    iconSize: 22,
-                    icon: Icon(
-                      Icons.copy,
-                      color: Theme.of(context).colorScheme.primary,
+                      },
                     ),
-                    style: IconButton.styleFrom(
-                      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    IconButton(
+                      iconSize: 22,
+                      icon: Icon(
+                        Icons.copy,
+                        color: Theme.of(context).colorScheme.primary,
+                      ),
+                      style: IconButton.styleFrom(
+                        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                      ),
+                      onPressed: () {
+                        final rootCtx = logicRootContext;
+                        Navigator.pop(context);
+                        final newCourse = course.copyWith();
+                        newCourse.name = '${course.name}${l10n.copySuffix}';
+                        if (rootCtx.mounted) {
+                          popupOrNavigate(
+                            rootCtx,
+                            CourseEditPage(course: newCourse),
+                          );
+                        }
+                      },
                     ),
-                    onPressed: () {
-                      final rootCtx = logicRootContext;
-                      Navigator.pop(context);
-                      final newCourse = course.copyWith();
-                      newCourse.name = '${course.name}${l10n.copySuffix}';
-                      if (rootCtx.mounted) {
-                        popupOrNavigate(
-                          rootCtx,
-                          CourseEditPage(course: newCourse),
-                        );
-                      }
-                    },
-                  ),
-                  IconButton(
-                    iconSize: 22,
-                    icon: Icon(
-                      Icons.edit_outlined,
-                      color: Theme.of(context).colorScheme.primary,
+                    IconButton(
+                      iconSize: 22,
+                      icon: Icon(
+                        Icons.edit_outlined,
+                        color: Theme.of(context).colorScheme.primary,
+                      ),
+                      style: IconButton.styleFrom(
+                        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                      ),
+                      onPressed: () {
+                        final rootCtx = logicRootContext;
+                        Navigator.pop(context);
+                        if (rootCtx.mounted) {
+                          popupOrNavigate(
+                            rootCtx,
+                            CourseEditPage(course: course),
+                          );
+                        }
+                      },
                     ),
-                    style: IconButton.styleFrom(
-                      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                    ),
-                    onPressed: () {
-                      final rootCtx = logicRootContext;
-                      Navigator.pop(context);
-                      if (rootCtx.mounted) {
-                        popupOrNavigate(
-                          rootCtx,
-                          CourseEditPage(course: course),
-                        );
-                      }
-                    },
-                  ),
+                  ],
                 ],
               ),
             ),

--- a/lib/widgets/course/course_grid.dart
+++ b/lib/widgets/course/course_grid.dart
@@ -160,6 +160,7 @@ class _CourseGridState extends State<CourseGrid> {
                                 .where((c) => c.dayOfWeek == day)
                                 .toList();
                             dayCourses.sort(_compareCoursesForLayout);
+                            dayCourses = _mergeSameSlotCourses(dayCourses);
                           } else {
                             dayCourses = selectVisibleCoursesForDay(
                               widget.courses
@@ -684,4 +685,66 @@ List<_TrackInfo> _assignCourseTracks(List<Course> courses) {
     final localTrack = overlapping.indexOf(i);
     return _TrackInfo(track: localTrack, totalTracks: overlapping.length);
   });
+}
+
+/// Merges courses with the same name, day, and section range into one card.
+/// Reduces track count and shows combined info in compact format.
+List<Course> _mergeSameSlotCourses(List<Course> courses) {
+  if (courses.length <= 1) return courses;
+
+  final groups = <String, List<Course>>{};
+  for (final course in courses) {
+    final key =
+        '${course.name}|${course.dayOfWeek}|${course.startSection}|${course.endSection}';
+    groups.putIfAbsent(key, () => []).add(course);
+  }
+
+  if (groups.length == courses.length) return courses;
+
+  final result = <Course>[];
+  for (final group in groups.values) {
+    if (group.length == 1) {
+      result.add(group[0]);
+    } else {
+      // Only merge if same location; different locations → keep side-by-side tracks
+      final uniqueLocations = group.map((c) => c.location).toSet();
+      if (uniqueLocations.length == 1) {
+        result.add(_mergeCourseGroup(group));
+      } else {
+        result.addAll(group);
+      }
+    }
+  }
+  return result;
+}
+
+Course _mergeCourseGroup(List<Course> group) {
+  final first = group.first;
+
+  // Teacher: unique names (some fields already contain comma-separated names)
+  final teacher = group
+      .expand((c) => c.teacher.split(RegExp(r'[,，、]')))
+      .map((s) => s.trim())
+      .where((s) => s.isNotEmpty)
+      .toSet()
+      .join('\u3001');
+
+  // Location: unique values, no week annotations
+  final location = group.map((c) => c.location).toSet().join(' \u00b7 ');
+
+  final minWeek = group.map((c) => c.startWeek).reduce((a, b) => a < b ? a : b);
+  final maxWeek = group.map((c) => c.endWeek).reduce((a, b) => a > b ? a : b);
+
+  return Course(
+    name: first.name,
+    teacher: teacher,
+    location: location,
+    startWeek: minWeek,
+    endWeek: maxWeek,
+    dayOfWeek: first.dayOfWeek,
+    startSection: first.startSection,
+    endSection: first.endSection,
+    colorValue: first.colorValue,
+    weekType: first.weekType,
+  );
 }

--- a/lib/widgets/course/course_grid.dart
+++ b/lib/widgets/course/course_grid.dart
@@ -745,6 +745,8 @@ Course _mergeCourseGroup(List<Course> group) {
     startSection: first.startSection,
     endSection: first.endSection,
     colorValue: first.colorValue,
-    weekType: first.weekType,
+    weekType: group.map((c) => c.weekType).toSet().length == 1
+        ? first.weekType
+        : WeekType.every,
   );
 }

--- a/lib/widgets/course/course_grid.dart
+++ b/lib/widgets/course/course_grid.dart
@@ -75,7 +75,7 @@ class CourseGrid extends StatefulWidget {
     required this.courses,
     required this.config,
     required this.displayWeek,
-    required this.totalWeeks,
+    this.totalWeeks = 20,
     this.showAllWeeks = false,
     this.onCourseTap,
     this.onCourseLongPress,

--- a/lib/widgets/course/course_grid.dart
+++ b/lib/widgets/course/course_grid.dart
@@ -64,6 +64,7 @@ class CourseGrid extends StatefulWidget {
   final ScheduleConfig config;
   final int displayWeek;
   final int totalWeeks;
+  final bool forceActive;
   final void Function(Course course)? onCourseTap;
   final void Function(Course course)? onCourseLongPress;
   final void Function(int dayOfWeek, int section)? onEmptyTap;
@@ -75,6 +76,7 @@ class CourseGrid extends StatefulWidget {
     required this.config,
     required this.displayWeek,
     required this.totalWeeks,
+    this.forceActive = false,
     this.onCourseTap,
     this.onCourseLongPress,
     this.onEmptyTap,
@@ -152,14 +154,22 @@ class _CourseGridState extends State<CourseGrid> {
                           final day = widget.config.showWeekend
                               ? (dayIndex == 0 ? 7 : dayIndex)
                               : dayIndex + 1;
-                          final dayCourses = selectVisibleCoursesForDay(
-                            widget.courses
+                          List<Course> dayCourses;
+                          if (widget.forceActive) {
+                            dayCourses = widget.courses
                                 .where((c) => c.dayOfWeek == day)
-                                .toList(),
-                            widget.displayWeek,
-                            showNonCurrentWeekCourses:
-                                widget.config.showNonCurrentWeekCourses,
-                          );
+                                .toList();
+                            dayCourses.sort(_compareCoursesForLayout);
+                          } else {
+                            dayCourses = selectVisibleCoursesForDay(
+                              widget.courses
+                                  .where((c) => c.dayOfWeek == day)
+                                  .toList(),
+                              widget.displayWeek,
+                              showNonCurrentWeekCourses:
+                                  widget.config.showNonCurrentWeekCourses,
+                            );
+                          }
                           return _buildDayColumn(
                             context,
                             day,
@@ -232,16 +242,28 @@ class _CourseGridState extends State<CourseGrid> {
                         daysFromMonday,
                   ),
                 );
-                final isToday = date.isAtSameMomentAs(today);
-                final specialDay = HolidayUtils.getSpecialDay(date);
-                final isHoliday = specialDay.type == SpecialDayType.holiday;
-                final isFestival = specialDay.type == SpecialDayType.festival;
-                final isSolarTerm = specialDay.type == SpecialDayType.solarTerm;
+                final isToday =
+                    !widget.forceActive && date.isAtSameMomentAs(today);
+                final specialDay = !widget.forceActive
+                    ? HolidayUtils.getSpecialDay(date)
+                    : SpecialDayInfo(type: SpecialDayType.ordinary);
+                final isHoliday =
+                    !widget.forceActive &&
+                    specialDay.type == SpecialDayType.holiday;
+                final isFestival =
+                    !widget.forceActive &&
+                    specialDay.type == SpecialDayType.festival;
+                final isSolarTerm =
+                    !widget.forceActive &&
+                    specialDay.type == SpecialDayType.solarTerm;
                 final isSpecial = isHoliday || isFestival || isSolarTerm;
 
                 return Expanded(
                   child: GestureDetector(
-                    onTap: isSpecial && widget.onSpecialDayTap != null
+                    onTap:
+                        !widget.forceActive &&
+                            isSpecial &&
+                            widget.onSpecialDayTap != null
                         ? () => widget.onSpecialDayTap!(date, specialDay)
                         : null,
                     child: Container(
@@ -278,52 +300,53 @@ class _CourseGridState extends State<CourseGrid> {
                                     : theme.colorScheme.onSurface,
                               ),
                             ),
-                            Row(
-                              mainAxisSize: MainAxisSize.min,
-                              children: [
-                                Text(
-                                  l10n.dateMonthDay(date.month, date.day),
-                                  style: TextStyle(
-                                    fontSize: 10,
-                                    fontWeight: isToday
-                                        ? FontWeight.bold
-                                        : FontWeight.normal,
-                                    color: isHoliday
-                                        ? Colors.red
-                                        : isFestival
-                                        ? Colors.orange
-                                        : isSolarTerm
-                                        ? Colors.green
-                                        : isToday
-                                        ? theme.colorScheme.primary.withAlpha(
-                                            200,
-                                          )
-                                        : theme.colorScheme.onSurfaceVariant,
+                            if (!widget.forceActive)
+                              Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  Text(
+                                    l10n.dateMonthDay(date.month, date.day),
+                                    style: TextStyle(
+                                      fontSize: 10,
+                                      fontWeight: isToday
+                                          ? FontWeight.bold
+                                          : FontWeight.normal,
+                                      color: isHoliday
+                                          ? Colors.red
+                                          : isFestival
+                                          ? Colors.orange
+                                          : isSolarTerm
+                                          ? Colors.green
+                                          : isToday
+                                          ? theme.colorScheme.primary.withAlpha(
+                                              200,
+                                            )
+                                          : theme.colorScheme.onSurfaceVariant,
+                                    ),
                                   ),
-                                ),
-                                if (isHoliday) ...[
-                                  const SizedBox(width: 2),
-                                  _buildLabelBadge(
-                                    l10n.holidayLabel,
-                                    Colors.red,
-                                  ),
+                                  if (isHoliday) ...[
+                                    const SizedBox(width: 2),
+                                    _buildLabelBadge(
+                                      l10n.holidayLabel,
+                                      Colors.red,
+                                    ),
+                                  ],
+                                  if (isFestival) ...[
+                                    const SizedBox(width: 2),
+                                    _buildLabelBadge(
+                                      l10n.festivalLabel,
+                                      Colors.orange,
+                                    ),
+                                  ],
+                                  if (isSolarTerm) ...[
+                                    const SizedBox(width: 2),
+                                    _buildLabelBadge(
+                                      l10n.solarTermLabel,
+                                      Colors.green,
+                                    ),
+                                  ],
                                 ],
-                                if (isFestival) ...[
-                                  const SizedBox(width: 2),
-                                  _buildLabelBadge(
-                                    l10n.festivalLabel,
-                                    Colors.orange,
-                                  ),
-                                ],
-                                if (isSolarTerm) ...[
-                                  const SizedBox(width: 2),
-                                  _buildLabelBadge(
-                                    l10n.solarTermLabel,
-                                    Colors.green,
-                                  ),
-                                ],
-                              ],
-                            ),
+                              ),
                           ],
                         ),
                       ),
@@ -502,6 +525,7 @@ class _CourseGridState extends State<CourseGrid> {
                     course: course,
                     config: widget.config,
                     displayWeek: widget.displayWeek,
+                    forceActive: widget.forceActive,
                     onTap: widget.onCourseTap != null
                         ? () => widget.onCourseTap!(course)
                         : null,

--- a/lib/widgets/course/course_grid.dart
+++ b/lib/widgets/course/course_grid.dart
@@ -64,7 +64,7 @@ class CourseGrid extends StatefulWidget {
   final ScheduleConfig config;
   final int displayWeek;
   final int totalWeeks;
-  final bool forceActive;
+  final bool showAllWeeks;
   final void Function(Course course)? onCourseTap;
   final void Function(Course course)? onCourseLongPress;
   final void Function(int dayOfWeek, int section)? onEmptyTap;
@@ -76,7 +76,7 @@ class CourseGrid extends StatefulWidget {
     required this.config,
     required this.displayWeek,
     required this.totalWeeks,
-    this.forceActive = false,
+    this.showAllWeeks = false,
     this.onCourseTap,
     this.onCourseLongPress,
     this.onEmptyTap,
@@ -155,7 +155,7 @@ class _CourseGridState extends State<CourseGrid> {
                               ? (dayIndex == 0 ? 7 : dayIndex)
                               : dayIndex + 1;
                           List<Course> dayCourses;
-                          if (widget.forceActive) {
+                          if (widget.showAllWeeks) {
                             dayCourses = widget.courses
                                 .where((c) => c.dayOfWeek == day)
                                 .toList();
@@ -243,25 +243,25 @@ class _CourseGridState extends State<CourseGrid> {
                   ),
                 );
                 final isToday =
-                    !widget.forceActive && date.isAtSameMomentAs(today);
-                final specialDay = !widget.forceActive
+                    !widget.showAllWeeks && date.isAtSameMomentAs(today);
+                final specialDay = !widget.showAllWeeks
                     ? HolidayUtils.getSpecialDay(date)
                     : SpecialDayInfo(type: SpecialDayType.ordinary);
                 final isHoliday =
-                    !widget.forceActive &&
+                    !widget.showAllWeeks &&
                     specialDay.type == SpecialDayType.holiday;
                 final isFestival =
-                    !widget.forceActive &&
+                    !widget.showAllWeeks &&
                     specialDay.type == SpecialDayType.festival;
                 final isSolarTerm =
-                    !widget.forceActive &&
+                    !widget.showAllWeeks &&
                     specialDay.type == SpecialDayType.solarTerm;
                 final isSpecial = isHoliday || isFestival || isSolarTerm;
 
                 return Expanded(
                   child: GestureDetector(
                     onTap:
-                        !widget.forceActive &&
+                        !widget.showAllWeeks &&
                             isSpecial &&
                             widget.onSpecialDayTap != null
                         ? () => widget.onSpecialDayTap!(date, specialDay)
@@ -300,7 +300,7 @@ class _CourseGridState extends State<CourseGrid> {
                                     : theme.colorScheme.onSurface,
                               ),
                             ),
-                            if (!widget.forceActive)
+                            if (!widget.showAllWeeks)
                               Row(
                                 mainAxisSize: MainAxisSize.min,
                                 children: [
@@ -476,116 +476,212 @@ class _CourseGridState extends State<CourseGrid> {
     final afternoonEnd =
         widget.config.morningSections + widget.config.afternoonSections;
 
+    // Compute track assignments for all-weeks overlay mode
+    final trackInfos = widget.showAllWeeks && dayCourses.length > 1
+        ? _assignCourseTracks(dayCourses)
+        : null;
+
     return Expanded(
       child: SizedBox(
         height: rowHeight * sections,
-        child: Stack(
-          children: [
-            // Grid lines (conditionally rendered)
-            if (appConfig.showCourseGrid.value)
-              ...List.generate(sections, (i) {
-                final isBoundary =
-                    (i + 1 == morningEnd) || (i + 1 == afternoonEnd);
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            final columnWidth = constraints.maxWidth;
+            return Stack(
+              children: [
+                // Grid lines (conditionally rendered)
+                if (appConfig.showCourseGrid.value)
+                  ...List.generate(sections, (i) {
+                    final isBoundary =
+                        (i + 1 == morningEnd) || (i + 1 == afternoonEnd);
 
-                return Positioned(
-                  top: i * rowHeight,
-                  left: 0,
-                  right: 0,
-                  height: rowHeight,
-                  child: Container(
-                    decoration: BoxDecoration(
-                      border: Border(
-                        bottom: BorderSide(
-                          color: isBoundary
-                              ? theme.colorScheme.primary.withAlpha(150)
-                              : theme.colorScheme.outlineVariant,
-                          width: isBoundary ? 1.5 : 0.5,
-                        ),
-                        right: BorderSide(
-                          color: theme.colorScheme.outlineVariant,
-                          width: 0.5,
+                    return Positioned(
+                      top: i * rowHeight,
+                      left: 0,
+                      right: 0,
+                      height: rowHeight,
+                      child: Container(
+                        decoration: BoxDecoration(
+                          border: Border(
+                            bottom: BorderSide(
+                              color: isBoundary
+                                  ? theme.colorScheme.primary.withAlpha(150)
+                                  : theme.colorScheme.outlineVariant,
+                              width: isBoundary ? 1.5 : 0.5,
+                            ),
+                            right: BorderSide(
+                              color: theme.colorScheme.outlineVariant,
+                              width: 0.5,
+                            ),
+                          ),
                         ),
                       ),
+                    );
+                  }),
+                // Course cards
+                ...dayCourses.asMap().entries.map((entry) {
+                  final index = entry.key;
+                  final course = entry.value;
+                  final top = (course.startSection - 1) * rowHeight;
+                  final courseHeight =
+                      (course.endSection - course.startSection + 1) *
+                          rowHeight -
+                      2;
+
+                  final cardWidget = SizedBox(
+                    child: CourseCard(
+                      course: course,
+                      config: widget.config,
+                      displayWeek: widget.displayWeek,
+                      showAllWeeks: widget.showAllWeeks,
+                      onTap: widget.onCourseTap != null
+                          ? () => widget.onCourseTap!(course)
+                          : null,
+                      onLongPress: widget.onCourseLongPress != null
+                          ? () => widget.onCourseLongPress!(course)
+                          : null,
                     ),
-                  ),
-                );
-              }),
-            // Course cards
-            ...dayCourses.map((course) {
-              final top = (course.startSection - 1) * rowHeight;
-              final courseHeight =
-                  (course.endSection - course.startSection + 1) * rowHeight - 2;
-              return Positioned(
-                top: top + 1,
-                left: 1,
-                right: 1,
-                height: courseHeight,
-                child: SizedBox(
-                  child: CourseCard(
-                    course: course,
-                    config: widget.config,
-                    displayWeek: widget.displayWeek,
-                    forceActive: widget.forceActive,
-                    onTap: widget.onCourseTap != null
-                        ? () => widget.onCourseTap!(course)
-                        : null,
-                    onLongPress: widget.onCourseLongPress != null
-                        ? () => widget.onCourseLongPress!(course)
-                        : null,
-                  ),
-                ),
-              );
-            }),
-            // Invisible tap targets for empty cells, and Add icon for selected empty cell
-            ...List.generate(sections, (i) {
-              final section = i + 1;
-              // Skip sections that are covered by a course card
-              final hasCourse = dayCourses.any(
-                (c) => section >= c.startSection && section <= c.endSection,
-              );
-              if (hasCourse) return const SizedBox.shrink();
+                  );
 
-              final isSelected =
-                  _selectedEmptyDay == day && _selectedEmptySection == section;
+                  if (widget.showAllWeeks && trackInfos != null) {
+                    final info = trackInfos[index];
+                    final trackWidth = columnWidth / info.totalTracks;
+                    return Positioned(
+                      top: top + 1,
+                      left: info.track * trackWidth + 1,
+                      width: trackWidth - 2,
+                      height: courseHeight,
+                      child: cardWidget,
+                    );
+                  }
 
-              return Positioned(
-                top: i * rowHeight,
-                left: 0,
-                right: 0,
-                height: rowHeight,
-                child: GestureDetector(
-                  behavior: HitTestBehavior.translucent,
-                  onTap: widget.onEmptyTap != null
-                      ? () => _handleEmptyTap(day, section)
-                      : null,
-                  child: isSelected
-                      ? Container(
-                          margin: const EdgeInsets.all(2),
-                          decoration: BoxDecoration(
-                            color: theme.colorScheme.primary.withAlpha(
-                              100,
-                            ), // e.g. pinkish/primary with opacity
-                            borderRadius: BorderRadius.circular(6),
-                            border: Border.all(
-                              color: theme.colorScheme.primary.withAlpha(150),
-                              width: 1,
-                            ),
-                          ),
-                          child: Center(
-                            child: Icon(
-                              Icons.add,
-                              color: theme.colorScheme.onPrimaryContainer,
-                              size: 32,
-                            ),
-                          ),
-                        )
-                      : const SizedBox.shrink(),
-                ),
-              );
-            }),
-          ],
+                  return Positioned(
+                    top: top + 1,
+                    left: 1,
+                    right: 1,
+                    height: courseHeight,
+                    child: cardWidget,
+                  );
+                }),
+                // Invisible tap targets for empty cells, and Add icon for selected empty cell
+                if (!widget.showAllWeeks)
+                  ...List.generate(sections, (i) {
+                    final section = i + 1;
+                    // Skip sections that are covered by a course card
+                    final hasCourse = dayCourses.any(
+                      (c) =>
+                          section >= c.startSection && section <= c.endSection,
+                    );
+                    if (hasCourse) return const SizedBox.shrink();
+
+                    final isSelected =
+                        _selectedEmptyDay == day &&
+                        _selectedEmptySection == section;
+
+                    return Positioned(
+                      top: i * rowHeight,
+                      left: 0,
+                      right: 0,
+                      height: rowHeight,
+                      child: GestureDetector(
+                        behavior: HitTestBehavior.translucent,
+                        onTap: widget.onEmptyTap != null
+                            ? () => _handleEmptyTap(day, section)
+                            : null,
+                        child: isSelected
+                            ? Container(
+                                margin: const EdgeInsets.all(2),
+                                decoration: BoxDecoration(
+                                  color: theme.colorScheme.primary.withAlpha(
+                                    100,
+                                  ), // e.g. pinkish/primary with opacity
+                                  borderRadius: BorderRadius.circular(6),
+                                  border: Border.all(
+                                    color: theme.colorScheme.primary.withAlpha(
+                                      150,
+                                    ),
+                                    width: 1,
+                                  ),
+                                ),
+                                child: Center(
+                                  child: Icon(
+                                    Icons.add,
+                                    color: theme.colorScheme.onPrimaryContainer,
+                                    size: 32,
+                                  ),
+                                ),
+                              )
+                            : const SizedBox.shrink(),
+                      ),
+                    );
+                  }),
+              ],
+            );
+          },
         ),
       ),
     );
   }
+}
+
+/// Track assignment info for side-by-side course layout in all-weeks mode.
+class _TrackInfo {
+  final int track;
+  final int totalTracks;
+  const _TrackInfo({required this.track, required this.totalTracks});
+}
+
+/// Assigns overlapping courses to vertical tracks for side-by-side layout.
+List<_TrackInfo> _assignCourseTracks(List<Course> courses) {
+  if (courses.isEmpty) return [];
+  if (courses.length == 1) {
+    return [const _TrackInfo(track: 0, totalTracks: 1)];
+  }
+
+  // Sort by start section, then longer courses first for stability
+  final indexed = courses.asMap().entries.toList()
+    ..sort((a, b) {
+      final cmp = a.value.startSection.compareTo(b.value.startSection);
+      if (cmp != 0) return cmp;
+      final aDuration = a.value.endSection - a.value.startSection;
+      final bDuration = b.value.endSection - b.value.startSection;
+      return bDuration.compareTo(aDuration);
+    });
+
+  final trackEnds = <int>[];
+  final assignments = List<int>.filled(courses.length, -1);
+
+  for (final entry in indexed) {
+    final originalIndex = entry.key;
+    final course = entry.value;
+
+    int assignedTrack = -1;
+    for (int t = 0; t < trackEnds.length; t++) {
+      if (trackEnds[t] < course.startSection) {
+        assignedTrack = t;
+        break;
+      }
+    }
+    if (assignedTrack == -1) {
+      assignedTrack = trackEnds.length;
+      trackEnds.add(0);
+    }
+    trackEnds[assignedTrack] = course.endSection;
+    assignments[originalIndex] = assignedTrack;
+  }
+
+  // Remap: for each course, recompute track/totalTracks based only on
+  // courses that actually overlap at its time slot (not global maximum).
+  return List.generate(courses.length, (i) {
+    final course = courses[i];
+    final overlapping = <int>[];
+    for (int j = 0; j < courses.length; j++) {
+      if (_coursesOverlapInSections(courses[j], course)) {
+        overlapping.add(j);
+      }
+    }
+    overlapping.sort((a, b) => assignments[a].compareTo(assignments[b]));
+    final localTrack = overlapping.indexOf(i);
+    return _TrackInfo(track: localTrack, totalTracks: overlapping.length);
+  });
 }


### PR DESCRIPTION
## 班级课表查询功能

### 背景

在校园功能模块中新增"班级课表"入口，用户可通过多级筛选查询全校任一班级的课表，方便查看其他班级的课程安排，以及查看下学期预置课表。

### Commits

| Hash | 描述 |
|------|------|
| `76edd33` | feat: 实现班级课表查询功能 |
| `255d9d3` | refactor: 优化级联下拉竞态条件与周末课表显示 |
| `a26e64c` | fix: 拆分共享计数器防止级联下拉请求被误丢弃 |

### 新增文件

| 文件 | 行数 | 说明 |
|------|------|------|
| class_schedule_inquiry_page.dart | 539 | 班级课表列表页：5级级联筛选 + 分页班级列表 |
| class_schedule_inquiry_detail_page.dart | 478 | 班级课表详情页：Stack 课表网格 + 课程详情列表 |
| class_schedule_inquiry_model.dart | 139 | 6个数据模型类 |

### 修改文件

| 文件 | 变更 |
|------|------|
| zhjw_api_service.dart | +5 API 方法：`fetchClassScheduleInquiryIndex` / `fetchSubjectsByDepartment` / `fetchClassOptions` / `fetchClassList` / `fetchClassSchedule`；新增通用 HTML select 解析工具 `_parseSelectOptions`；修复 `_parseOptions`/`_parseGradeOptions` 正则跨行匹配（`(.*?)` → `[\\s\\S]*?`） |
| campus_item_config.dart | 注册 `campusItemClassScheduleInquiry` 到 `utilitiesSection` |
| constants.dart | 添加 `dockIdClassScheduleInquiry = 'class_schedule_inquiry'` |
| app_zh.arb | +13 条中文 i18n |
| app_en.arb | +13 条英文 i18n |
| app_localizations.dart | 自动生成 |
| app_localizations_zh.dart | 自动生成 |
| app_localizations_en.dart | 自动生成 |

### 架构设计

**列表页** — `ClassScheduleInquiryPage`

```
┌─ FilterBar (Card) ──────────────────────────┐
│  学年学期 [▼]        年级 [▼]              │
│  院系 [▼]                                  │
│  专业 [▼]         班级 [▼]                 │
│  [ 🔍 查询 ]                               │
├─ ClassList (RefreshIndicator) ──────────────┤
│  Card: 班级名 (专业 · 院系)  >             │
│  Card: 班级名 (专业 · 院系)  >             │
│  ...                                       │
│  [ 加载更多 ]                               │
└─────────────────────────────────────────────┘
```

- **5级联动**：学年学期 → 年级 → 院系 → 专业 → 班级，上级变化自动重置下级
- **`ValueKey` + `initialValue`**：解决 Flutter 3.33 `value` 弃用后下拉不回显的问题，级联变化时通过 key 变化强制重建 widget
- **`_subjectReqSeq` / `_classOptionReqSeq` 双计数器**：`_loadSubjects` 和 `_loadClassOptions` 各自独立计数，避免共用一个计数器导致专业列表响应被误丢弃
- **分页**：`_pageSize = 30`，底部"加载更多"按钮，`_hasMore` 根据 `totalCount` 判断

**详情页** — `ClassScheduleInquiryDetailPage`

```
┌─ AppBar ────────────────────────────────────┐
│  班级名称                                    │
│  培养方案名称                                │
├─ ScheduleGrid ──────────────────────────────┤
│  │ 周一  周二  周三  周四  周五 (或7天)    │
│  1│ [课卡]                                  │
│  2│                                         │
│  3│ [课卡] [课卡]                           │
│ ...│                                         │
│ 12│                                         │
├─ 课程详情 ──────────────────────────────────┤
│  ▎ 课程名称                                  │
│  ▎ 课程号 · 课序号                           │
│  ▎ 👤 教师                                   │
│  ▎ 📅 周次说明                               │
│  ▎ 📍 校区 · 教学楼 · 教室                  │
└─────────────────────────────────────────────┘
```

- **Stack 布局**：`Positioned` 按 `startPeriod × rowHeight` 定位，高度 `duration × rowHeight`，`const double rowHeight = 72`
- **12节 × 5/7天**：自动检测是否有周末课程（`dayOfWeek > 5`），有则扩展为7列，无则保持5天，列宽 `Expanded` 等分自适应
- **复用 `CourseCard`**：通过 `_toCourse()` 适配器转换为 `Course` 模型，与主页课表视觉完全统一（圆角6、实色背景、亮度自适应文字颜色、fontSize 12/11）
- **`_getCourseColor`**：基于 `courseCode.hashCode` 从10色调色板中取色，确保同一课程色彩一致

### API 层

5个新方法均遵循项目现有模式：

```
_request<T>(fn) → retryOnUnauthenticated(getClient, fn)
                → 15s timeout
                → UnauthenticatedException 自动捕获重试
```

| API | 方法 | 响应格式 |
|-----|------|---------|
| `fetchClassScheduleInquiryIndex` | GET HTML → `_parseSelectOptions` | 学期/年级/院系选项 |
| `fetchSubjectsByDepartment` | GET JSON → `SubjectOption` | `List<SubjectOption>` |
| `fetchClassOptions` | GET JSON → `ClassOption` | `List<ClassOption>` |
| `fetchClassList` | POST JSON → `[0].records` + `[0].pageContext.totalCount` | `({List<ClassInfo>, totalCount})` |
| `fetchClassSchedule` | GET JSON → `[0]` | `List<ClassScheduleInquiryItem>` |

**HTML 解析**：`_parseSelectOptions` 通用工具方法，使用 `[\\s\\S]*?` 跨行匹配 `<option>` 内容，替代原来 `(.*?)` 无法匹配换行的问题。

### 数据模型

```dart
ClassInfo              — 班级列表项（planCode, classCode, planName, className...）
SemesterOption         — 学年学期选项（value, label）
DepartmentOption       — 院系选项（value, name）
SubjectOption          — 专业选项（code, name）
ClassOption            — 班级选项（code, name）
ClassScheduleInquiryItem — 课表课程（dayOfWeek, startPeriod, duration, 
                            courseCode, courseSeq, courseName, teacherName,
                            weeksDescription, campus, building, classroom）
```

### 错误处理

- **`sessionExpired`**：Session 过期 → 自动跳登录页 + SnackBar 提示
- **`loadFailed`**：网络/解析错误 → 显示重试按钮
- **`mounted` 守卫**：每个 `await` 后均有 `if (!mounted) return;`，确保不会在已 dispose 后操作 State
- **`_requestSeq` 防竞态**：过期异步响应自动丢弃，避免快速切换选项时数据错乱