### PR TITLE
refactor(theme): adopt Material 3 Expressive tokens and semantic colors

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -9,6 +9,8 @@ import 'package:bugaoshan/pages/wizard/eula_gate_page.dart';
 import 'package:bugaoshan/pages/wizard/wizard_page.dart';
 import 'package:bugaoshan/providers/app_config_provider.dart';
 import 'package:bugaoshan/services/background_cache_service.dart';
+import 'package:bugaoshan/theme/m3e_tokens.dart';
+import 'package:bugaoshan/theme/semantic_colors.dart';
 import 'package:bugaoshan/widgets/common/session_expired_listener.dart';
 import 'package:bugaoshan/widgets/eula_content.dart';
 import 'package:bugaoshan/widgets/route/mouse_back_handler.dart';
@@ -103,14 +105,36 @@ class _MyAppState extends State<MyApp> {
     final seedColor = _appConfig.themeColorMode.value == ThemeColorMode.system
         ? SystemTheme.accentColor.accent
         : _appConfig.themeColor.value;
+    final colorScheme = ColorScheme.fromSeed(
+      seedColor: seedColor,
+      brightness: brightness,
+    );
     final baseTheme = ThemeData(
-      colorScheme: ColorScheme.fromSeed(
-        seedColor: seedColor,
-        brightness: brightness,
-      ),
+      useMaterial3: true,
+      colorScheme: colorScheme,
       pageTransitionsTheme: _pageTransitionsTheme,
       appBarTheme: _appBarTheme,
       navigationBarTheme: _navigationBarTheme,
+      cardTheme: CardThemeData(
+        elevation: 0,
+        margin: const EdgeInsets.only(bottom: 16),
+        shape: AppShapes.outlined(
+          radius: AppRadius.lg,
+          outlineColor: colorScheme.outline.withValues(alpha: 0.2),
+        ),
+      ),
+      filledButtonTheme: FilledButtonThemeData(
+        style: FilledButton.styleFrom(
+          shape: const RoundedRectangleBorder(
+            borderRadius: BorderRadius.all(Radius.circular(20)),
+          ),
+        ),
+      ),
+      extensions: <ThemeExtension<dynamic>>[
+        brightness == Brightness.dark
+            ? SemanticColors.dark
+            : SemanticColors.light,
+      ],
     );
 
     TextTheme textTheme = baseTheme.textTheme;

--- a/lib/pages/about/about_page.dart
+++ b/lib/pages/about/about_page.dart
@@ -8,6 +8,7 @@ import 'package:bugaoshan/utils/open_link.dart'
     show openDeveloperTeam, openProjectRepository;
 import 'package:bugaoshan/pages/about/release_notes_page.dart';
 import 'package:bugaoshan/pages/settings/eula_status_page.dart';
+import 'package:bugaoshan/theme/m3e_tokens.dart';
 import 'package:bugaoshan/pages/test/test_page.dart';
 import 'package:bugaoshan/widgets/common/info_card.dart';
 import 'package:bugaoshan/widgets/common/styled_tile.dart';
@@ -211,7 +212,7 @@ class _AboutPageState extends State<AboutPage> {
             width: 100,
             height: 100,
             decoration: BoxDecoration(
-              borderRadius: BorderRadius.circular(24),
+              borderRadius: AppRadius.xxl.borderRadius,
               boxShadow: [
                 BoxShadow(
                   color: primaryColor.withValues(alpha: 0.2),
@@ -221,7 +222,7 @@ class _AboutPageState extends State<AboutPage> {
               ],
             ),
             child: ClipRRect(
-              borderRadius: BorderRadius.circular(24),
+              borderRadius: AppRadius.xxl.borderRadius,
               child: Image.asset('assets/icon.png', fit: BoxFit.cover),
             ),
           ),

--- a/lib/pages/auth/scu_login_page.dart
+++ b/lib/pages/auth/scu_login_page.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 import 'package:bugaoshan/widgets/route/router_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
+import 'package:bugaoshan/theme/m3e_tokens.dart';
 import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/providers/scu_auth_provider.dart';
 import 'package:bugaoshan/services/auth/scu_auth.dart' show CaptchaResult;
@@ -183,7 +184,7 @@ class _ScuLoginPageState extends State<ScuLoginPage> {
       Container(
         width: 88,
         decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(12),
+          borderRadius: AppRadius.md.borderRadius,
           boxShadow: [
             BoxShadow(
               color: Colors.black.withValues(alpha: 0.08),
@@ -193,7 +194,7 @@ class _ScuLoginPageState extends State<ScuLoginPage> {
           ],
         ),
         child: ClipRRect(
-          borderRadius: BorderRadius.circular(12),
+          borderRadius: AppRadius.md.borderRadius,
           child: Image.asset('assets/scu.webp', fit: BoxFit.cover),
         ),
       ),
@@ -379,7 +380,7 @@ class _CaptchaRow extends StatelessWidget {
             height: 56,
             decoration: BoxDecoration(
               border: Border.all(color: Theme.of(context).dividerColor),
-              borderRadius: BorderRadius.circular(4),
+              borderRadius: AppRadius.xs.borderRadius,
             ),
             child: loading
                 ? const Center(
@@ -391,7 +392,7 @@ class _CaptchaRow extends StatelessWidget {
                   )
                 : captcha != null
                 ? ClipRRect(
-                    borderRadius: BorderRadius.circular(3),
+                    borderRadius: AppRadius.xs.borderRadius,
                     child: Image.memory(
                       _decodeBase64Image(captcha!.captchaBase64),
                       fit: BoxFit.contain,

--- a/lib/pages/campus/academic_calendar/academic_calendar_page.dart
+++ b/lib/pages/campus/academic_calendar/academic_calendar_page.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/widgets/common/error_widgets.dart';
+import 'package:bugaoshan/theme/m3e_tokens.dart';
 import 'package:bugaoshan/widgets/common/image_viewer.dart';
 import 'package:http/http.dart' as http;
 
@@ -192,7 +193,7 @@ class _AcademicCalendarPageState extends State<AcademicCalendarPage> {
             onTap: () =>
                 showFullScreenImageViewer(context, imageUrl: _imageUrls[index]),
             child: ClipRRect(
-              borderRadius: BorderRadius.circular(12),
+              borderRadius: AppRadius.md.borderRadius,
               child: Image.network(
                 _imageUrls[index],
                 fit: BoxFit.fitWidth,

--- a/lib/pages/campus/balance_query/widgets/balance_card.dart
+++ b/lib/pages/campus/balance_query/widgets/balance_card.dart
@@ -3,6 +3,7 @@ import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/providers/balance_query_provider.dart';
 import 'package:bugaoshan/services/api/balance_query_service.dart';
 import 'package:bugaoshan/providers/app_config_provider.dart';
+import 'package:bugaoshan/theme/m3e_tokens.dart';
 import 'package:bugaoshan/widgets/dialog/dialog.dart';
 
 class BalanceCard extends StatefulWidget {
@@ -121,7 +122,7 @@ class BalanceCardState extends State<BalanceCard> {
                   padding: const EdgeInsets.all(12),
                   decoration: BoxDecoration(
                     color: widget.iconColor.withValues(alpha: 0.15),
-                    borderRadius: BorderRadius.circular(12),
+                    borderRadius: AppRadius.md.borderRadius,
                   ),
                   child: Icon(widget.icon, color: widget.iconColor, size: 28),
                 ),

--- a/lib/pages/campus/balance_query/widgets/bind_room_dialog.dart
+++ b/lib/pages/campus/balance_query/widgets/bind_room_dialog.dart
@@ -3,6 +3,7 @@ import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/providers/balance_query_provider.dart';
 import 'package:bugaoshan/providers/scu_auth_provider.dart';
+import 'package:bugaoshan/theme/m3e_tokens.dart';
 import 'package:bugaoshan/services/api/balance_query_service.dart';
 import 'package:bugaoshan/providers/app_config_provider.dart';
 import 'package:bugaoshan/widgets/dialog/dialog.dart';
@@ -229,7 +230,7 @@ class BindRoomDialogState extends State<BindRoomDialog> {
                   padding: const EdgeInsets.all(12),
                   decoration: BoxDecoration(
                     color: Theme.of(context).colorScheme.errorContainer,
-                    borderRadius: BorderRadius.circular(8),
+                    borderRadius: AppRadius.sm.borderRadius,
                   ),
                   child: Text(
                     _error!,
@@ -505,7 +506,7 @@ class BindRoomDialogState extends State<BindRoomDialog> {
             padding: const EdgeInsets.all(12),
             decoration: BoxDecoration(
               color: Theme.of(context).colorScheme.surfaceContainerHighest,
-              borderRadius: BorderRadius.circular(8),
+              borderRadius: AppRadius.sm.borderRadius,
             ),
             child: Row(
               children: [Text('${auth.userRealname} (${auth.userNumber})')],

--- a/lib/pages/campus/ccyl/activities_tab.dart
+++ b/lib/pages/campus/ccyl/activities_tab.dart
@@ -3,6 +3,7 @@ import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/providers/ccyl_provider.dart';
 import 'package:bugaoshan/pages/campus/ccyl/models/ccyl_models.dart';
+import 'package:bugaoshan/theme/m3e_tokens.dart';
 import 'package:bugaoshan/pages/campus/ccyl/activity_lib_detail_page.dart';
 import 'package:bugaoshan/widgets/common/error_widgets.dart';
 
@@ -186,7 +187,7 @@ class _ActivityCard extends StatelessWidget {
             ),
           );
         },
-        borderRadius: BorderRadius.circular(12),
+        borderRadius: AppRadius.md.borderRadius,
         child: Padding(
           padding: const EdgeInsets.all(16),
           child: Column(
@@ -220,7 +221,7 @@ class _ActivityCard extends StatelessWidget {
                       ),
                       decoration: BoxDecoration(
                         color: Theme.of(context).colorScheme.primaryContainer,
-                        borderRadius: BorderRadius.circular(4),
+                        borderRadius: AppRadius.xs.borderRadius,
                       ),
                       child: Text(
                         activity.levelName!,
@@ -277,7 +278,7 @@ class _ActivityCard extends StatelessWidget {
                           : (activity.doing
                                 ? Colors.green.shade100
                                 : Colors.orange.shade100),
-                      borderRadius: BorderRadius.circular(4),
+                      borderRadius: AppRadius.xs.borderRadius,
                     ),
                     child: Text(
                       activity.subscribed

--- a/lib/pages/campus/ccyl/activity_detail_page.dart
+++ b/lib/pages/campus/ccyl/activity_detail_page.dart
@@ -3,6 +3,7 @@ import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/providers/ccyl_provider.dart';
 import 'package:bugaoshan/pages/campus/ccyl/models/ccyl_models.dart';
+import 'package:bugaoshan/theme/m3e_tokens.dart';
 import 'package:bugaoshan/widgets/common/image_viewer.dart';
 
 class ActivityDetailPage extends StatefulWidget {
@@ -288,7 +289,7 @@ class _ActivityDetailPageState extends State<ActivityDetailPage> {
       onTap: () =>
           showFullScreenImageViewer(context, imageUrl: _activity!.poster),
       child: ClipRRect(
-        borderRadius: BorderRadius.circular(12),
+        borderRadius: AppRadius.md.borderRadius,
         child: Image.network(
           _activity!.poster,
           width: double.infinity,
@@ -336,7 +337,7 @@ class _ActivityDetailPageState extends State<ActivityDetailPage> {
                         : activity.status == 'A05'
                         ? Colors.blue.shade100
                         : Colors.orange.shade100,
-                    borderRadius: BorderRadius.circular(4),
+                    borderRadius: AppRadius.xs.borderRadius,
                   ),
                   child: Text(
                     activity.statusName ?? activity.status,

--- a/lib/pages/campus/ccyl/activity_lib_detail_page.dart
+++ b/lib/pages/campus/ccyl/activity_lib_detail_page.dart
@@ -3,6 +3,7 @@ import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/providers/ccyl_provider.dart';
 import 'package:bugaoshan/pages/campus/ccyl/models/ccyl_models.dart';
+import 'package:bugaoshan/theme/m3e_tokens.dart';
 import 'package:bugaoshan/pages/campus/ccyl/activity_detail_page.dart';
 
 class ActivityLibDetailPage extends StatefulWidget {
@@ -210,7 +211,7 @@ class _ActivityLibDetailPageState extends State<ActivityLibDetailPage> {
                     ),
                     decoration: BoxDecoration(
                       color: Colors.green.shade100,
-                      borderRadius: BorderRadius.circular(4),
+                      borderRadius: AppRadius.xs.borderRadius,
                     ),
                     child: Text(
                       l10n.ccylSubscribed,
@@ -241,7 +242,7 @@ class _ActivityLibDetailPageState extends State<ActivityLibDetailPage> {
                     ),
                     decoration: BoxDecoration(
                       color: Theme.of(context).colorScheme.primaryContainer,
-                      borderRadius: BorderRadius.circular(4),
+                      borderRadius: AppRadius.xs.borderRadius,
                     ),
                     child: Text(
                       lib.levelName!,
@@ -436,7 +437,7 @@ class _ActivityCard extends StatelessWidget {
             ),
           );
         },
-        borderRadius: BorderRadius.circular(12),
+        borderRadius: AppRadius.md.borderRadius,
         child: Padding(
           padding: const EdgeInsets.all(16),
           child: Column(
@@ -449,7 +450,7 @@ class _ActivityCard extends StatelessWidget {
                     height: 24,
                     decoration: BoxDecoration(
                       color: Theme.of(context).colorScheme.primaryContainer,
-                      borderRadius: BorderRadius.circular(12),
+                      borderRadius: AppRadius.md.borderRadius,
                     ),
                     child: Center(
                       child: Text(
@@ -478,7 +479,7 @@ class _ActivityCard extends StatelessWidget {
                       color: activity.status == 'A03'
                           ? Colors.green.shade100
                           : Colors.orange.shade100,
-                      borderRadius: BorderRadius.circular(4),
+                      borderRadius: AppRadius.xs.borderRadius,
                     ),
                     child: Text(
                       activity.statusName ?? activity.status,

--- a/lib/pages/campus/ccyl/credit_list_page.dart
+++ b/lib/pages/campus/ccyl/credit_list_page.dart
@@ -3,6 +3,7 @@ import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/providers/ccyl_provider.dart';
 import 'package:bugaoshan/pages/campus/ccyl/models/ccyl_models.dart';
+import 'package:bugaoshan/theme/m3e_tokens.dart';
 import 'package:bugaoshan/widgets/common/error_widgets.dart';
 
 class CreditListPage extends StatefulWidget {
@@ -448,7 +449,7 @@ class _CreditCard extends StatelessWidget {
       color: selected ? theme.colorScheme.primaryContainer : null,
       child: InkWell(
         onTap: selecting ? onToggle : null,
-        borderRadius: BorderRadius.circular(12),
+        borderRadius: AppRadius.md.borderRadius,
         child: Padding(
           padding: const EdgeInsets.all(16),
           child: Column(
@@ -528,7 +529,7 @@ class _StatusChip extends StatelessWidget {
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
       decoration: BoxDecoration(
         color: color.withAlpha(25),
-        borderRadius: BorderRadius.circular(4),
+        borderRadius: AppRadius.xs.borderRadius,
       ),
       child: Text(
         label,

--- a/lib/pages/campus/ccyl/my_activities_tab.dart
+++ b/lib/pages/campus/ccyl/my_activities_tab.dart
@@ -3,6 +3,7 @@ import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/providers/ccyl_provider.dart';
 import 'package:bugaoshan/pages/campus/ccyl/models/ccyl_models.dart';
+import 'package:bugaoshan/theme/m3e_tokens.dart';
 import 'package:bugaoshan/pages/campus/ccyl/activity_detail_page.dart';
 import 'package:bugaoshan/widgets/common/error_widgets.dart';
 
@@ -150,7 +151,7 @@ class _MyActivityCard extends StatelessWidget {
             ),
           );
         },
-        borderRadius: BorderRadius.circular(12),
+        borderRadius: AppRadius.md.borderRadius,
         child: Padding(
           padding: const EdgeInsets.all(16),
           child: Column(
@@ -236,7 +237,7 @@ class _MyActivityCard extends StatelessWidget {
                     ),
                     decoration: BoxDecoration(
                       color: _getStatusColor(activity.statusName),
-                      borderRadius: BorderRadius.circular(4),
+                      borderRadius: AppRadius.xs.borderRadius,
                     ),
                     child: Text(
                       activity.statusName ?? activity.status,

--- a/lib/pages/campus/ccyl/ordered_activities_tab.dart
+++ b/lib/pages/campus/ccyl/ordered_activities_tab.dart
@@ -3,6 +3,7 @@ import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/providers/ccyl_provider.dart';
 import 'package:bugaoshan/pages/campus/ccyl/models/ccyl_models.dart';
+import 'package:bugaoshan/theme/m3e_tokens.dart';
 import 'package:bugaoshan/pages/campus/ccyl/activity_lib_detail_page.dart';
 import 'package:bugaoshan/widgets/common/error_widgets.dart';
 
@@ -171,7 +172,7 @@ class _OrderedActivityCard extends StatelessWidget {
             ),
           );
         },
-        borderRadius: BorderRadius.circular(12),
+        borderRadius: AppRadius.md.borderRadius,
         child: Padding(
           padding: const EdgeInsets.all(16),
           child: Column(
@@ -205,7 +206,7 @@ class _OrderedActivityCard extends StatelessWidget {
                       ),
                       decoration: BoxDecoration(
                         color: Theme.of(context).colorScheme.primaryContainer,
-                        borderRadius: BorderRadius.circular(4),
+                        borderRadius: AppRadius.xs.borderRadius,
                       ),
                       child: Text(
                         activity.levelName!,

--- a/lib/pages/campus/class_schedule_inquiry/class_schedule_inquiry_detail_page.dart
+++ b/lib/pages/campus/class_schedule_inquiry/class_schedule_inquiry_detail_page.dart
@@ -3,6 +3,7 @@ import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/models/course.dart';
 import 'package:bugaoshan/pages/campus/models/class_schedule_inquiry_model.dart';
+import 'package:bugaoshan/theme/m3e_tokens.dart';
 import 'package:bugaoshan/providers/app_config_provider.dart';
 import 'package:bugaoshan/services/api/zhjw_api_service.dart';
 import 'package:bugaoshan/services/auth/scu_exceptions.dart';
@@ -146,9 +147,7 @@ class _ClassScheduleInquiryDetailPageState
                   context: context,
                   isScrollControlled: true,
                   shape: const RoundedRectangleBorder(
-                    borderRadius: BorderRadius.vertical(
-                      top: Radius.circular(20),
-                    ),
+                    borderRadius: AppShapes.sheetTopRadius,
                   ),
                   builder: (context) => CourseDetailSheet(course: course),
                 );

--- a/lib/pages/campus/classroom/classroom_detail_page.dart
+++ b/lib/pages/campus/classroom/classroom_detail_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/pages/campus/models/classroom_model.dart';
+import 'package:bugaoshan/theme/m3e_tokens.dart';
 
 class ClassroomDetailPage extends StatelessWidget {
   final ClassroomCampus campus;
@@ -195,7 +196,7 @@ class ClassroomDetailPage extends StatelessWidget {
       padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
       decoration: BoxDecoration(
         color: color.withValues(alpha: 0.15),
-        borderRadius: BorderRadius.circular(8),
+        borderRadius: AppRadius.sm.borderRadius,
       ),
       child: Row(
         mainAxisSize: MainAxisSize.min,
@@ -284,7 +285,7 @@ class ClassroomDetailPage extends StatelessWidget {
               padding: const EdgeInsets.symmetric(vertical: 4),
               decoration: BoxDecoration(
                 color: bgColor,
-                borderRadius: BorderRadius.circular(6),
+                borderRadius: AppRadius.sm.borderRadius,
               ),
               child: Text(
                 periodLabel,

--- a/lib/pages/campus/classroom/classroom_page.dart
+++ b/lib/pages/campus/classroom/classroom_page.dart
@@ -3,6 +3,7 @@ import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/pages/campus/classroom/classroom_detail_page.dart';
 import 'package:bugaoshan/pages/campus/models/classroom_model.dart';
+import 'package:bugaoshan/theme/m3e_tokens.dart';
 import 'package:bugaoshan/providers/scu_auth_provider.dart';
 import 'package:bugaoshan/services/api/zhjw_api_service.dart';
 import 'package:bugaoshan/services/auth/scu_exceptions.dart';
@@ -451,7 +452,7 @@ class _ClassroomPageState extends State<ClassroomPage> {
             ),
           );
         },
-        borderRadius: BorderRadius.circular(12),
+        borderRadius: AppRadius.md.borderRadius,
         child: Padding(
           padding: const EdgeInsets.all(12),
           child: Column(

--- a/lib/pages/campus/exam_plan/exam_plan_page.dart
+++ b/lib/pages/campus/exam_plan/exam_plan_page.dart
@@ -3,6 +3,7 @@ import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/pages/campus/exam_plan/models/exam_info.dart';
 import 'package:bugaoshan/providers/scu_auth_provider.dart';
+import 'package:bugaoshan/theme/m3e_tokens.dart';
 import 'package:bugaoshan/services/api/zhjw_api_service.dart';
 import 'package:bugaoshan/services/auth/scu_exceptions.dart';
 import 'package:bugaoshan/widgets/common/loading_widgets.dart';
@@ -231,7 +232,7 @@ class _ExamPlanPageState extends State<ExamPlanPage> {
                           ),
                           decoration: BoxDecoration(
                             color: primary.withValues(alpha: 0.1),
-                            borderRadius: BorderRadius.circular(6),
+                            borderRadius: AppRadius.sm.borderRadius,
                           ),
                           child: Text(
                             exam.week,
@@ -292,7 +293,7 @@ class _ExamPlanPageState extends State<ExamPlanPage> {
                           color: colorScheme.surfaceContainerHighest.withValues(
                             alpha: 0.5,
                           ),
-                          borderRadius: BorderRadius.circular(8),
+                          borderRadius: AppRadius.sm.borderRadius,
                         ),
                         child: Row(
                           children: [

--- a/lib/pages/campus/fitness_test/fitness_test_page.dart
+++ b/lib/pages/campus/fitness_test/fitness_test_page.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:bugaoshan/injection/injector.dart';
+import 'package:bugaoshan/theme/m3e_tokens.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/providers/scu_auth_provider.dart';
 import 'package:bugaoshan/services/auth/fitness_auth.dart';
@@ -326,7 +327,7 @@ class _FitnessTestPageState extends State<FitnessTestPage>
       margin: const EdgeInsets.only(bottom: 8),
       child: InkWell(
         onTap: () => _showNoticeDetail(notice, l10n),
-        borderRadius: BorderRadius.circular(12),
+        borderRadius: AppRadius.md.borderRadius,
         child: Padding(
           padding: const EdgeInsets.all(16),
           child: Column(
@@ -342,7 +343,7 @@ class _FitnessTestPageState extends State<FitnessTestPage>
                       ),
                       decoration: BoxDecoration(
                         color: Theme.of(context).colorScheme.primaryContainer,
-                        borderRadius: BorderRadius.circular(4),
+                        borderRadius: AppRadius.xs.borderRadius,
                       ),
                       child: Text(
                         l10n.fitnessTestSticky,
@@ -634,7 +635,7 @@ class _FitnessTestPageState extends State<FitnessTestPage>
                     ),
                     decoration: BoxDecoration(
                       color: gradeColor.withValues(alpha: 0.1),
-                      borderRadius: BorderRadius.circular(12),
+                      borderRadius: AppRadius.md.borderRadius,
                     ),
                     child: Text(
                       totalGrade,

--- a/lib/pages/campus/grades/custom_stats_tab.dart
+++ b/lib/pages/campus/grades/custom_stats_tab.dart
@@ -3,6 +3,7 @@ import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/models/scheme_score.dart';
 import 'package:bugaoshan/providers/grades_provider.dart';
+import 'package:bugaoshan/theme/m3e_tokens.dart';
 import 'package:bugaoshan/widgets/common/error_widgets.dart';
 import 'package:bugaoshan/widgets/common/stat_item.dart';
 import 'scheme_scores_tab.dart' show ScoreCardWidget;
@@ -356,7 +357,7 @@ class _TermSelectHeader extends StatelessWidget {
           ),
           InkWell(
             onTap: allSelected ? onDeselectAllInTerm : onSelectAllInTerm,
-            borderRadius: BorderRadius.circular(4),
+            borderRadius: AppRadius.xs.borderRadius,
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
               child: Row(

--- a/lib/pages/campus/grades/scheme_scores_tab.dart
+++ b/lib/pages/campus/grades/scheme_scores_tab.dart
@@ -3,6 +3,7 @@ import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/models/scheme_score.dart';
 import 'package:bugaoshan/providers/grades_provider.dart';
+import 'package:bugaoshan/theme/m3e_tokens.dart';
 import 'package:bugaoshan/widgets/common/error_widgets.dart';
 import 'package:bugaoshan/widgets/common/stat_item.dart';
 
@@ -314,7 +315,7 @@ class ScoreCardWidget extends StatelessWidget {
                         ),
                         decoration: BoxDecoration(
                           color: attrColor,
-                          borderRadius: BorderRadius.circular(4),
+                          borderRadius: AppRadius.xs.borderRadius,
                         ),
                         child: Text(
                           item.courseAttributeName,
@@ -360,7 +361,7 @@ class ScoreCardWidget extends StatelessWidget {
     if (onTap != null) {
       card = InkWell(
         onTap: onTap,
-        borderRadius: BorderRadius.circular(12),
+        borderRadius: AppRadius.md.borderRadius,
         child: card,
       );
     }

--- a/lib/pages/campus/plan_completion/plan_completion_page.dart
+++ b/lib/pages/campus/plan_completion/plan_completion_page.dart
@@ -3,6 +3,7 @@ import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/pages/campus/plan_completion/models/plan_completion.dart';
 import 'package:bugaoshan/providers/plan_completion_provider.dart';
+import 'package:bugaoshan/theme/m3e_tokens.dart';
 import 'package:bugaoshan/providers/scu_auth_provider.dart';
 import 'package:bugaoshan/widgets/common/loading_widgets.dart';
 import 'package:bugaoshan/widgets/common/login_required_widget.dart';
@@ -260,7 +261,7 @@ class _PlanCompletionPageState extends State<PlanCompletionPage> {
             ),
             const SizedBox(height: 4),
             ClipRRect(
-              borderRadius: BorderRadius.circular(4),
+              borderRadius: AppRadius.xs.borderRadius,
               child: LinearProgressIndicator(
                 value: progress,
                 minHeight: 4,
@@ -375,7 +376,7 @@ class _PlanCompletionPageState extends State<PlanCompletionPage> {
                   color: isPassed
                       ? Theme.of(context).colorScheme.primaryContainer
                       : Theme.of(context).colorScheme.errorContainer,
-                  borderRadius: BorderRadius.circular(4),
+                  borderRadius: AppRadius.xs.borderRadius,
                 ),
                 child: Text(
                   gradeDisplay,

--- a/lib/pages/campus/train_program/train_program_page.dart
+++ b/lib/pages/campus/train_program/train_program_page.dart
@@ -3,6 +3,7 @@ import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/pages/campus/train_program/models/train_program.dart';
 import 'package:bugaoshan/providers/train_program_provider.dart';
+import 'package:bugaoshan/theme/m3e_tokens.dart';
 import 'package:bugaoshan/providers/scu_auth_provider.dart';
 import 'package:bugaoshan/widgets/common/loading_widgets.dart';
 import 'package:bugaoshan/widgets/common/login_required_widget.dart';
@@ -231,7 +232,7 @@ class _TrainProgramPageState extends State<TrainProgramPage> {
                         padding: const EdgeInsets.all(8),
                         decoration: BoxDecoration(
                           color: Theme.of(context).colorScheme.primaryContainer,
-                          borderRadius: BorderRadius.circular(8),
+                          borderRadius: AppRadius.sm.borderRadius,
                         ),
                         child: Icon(
                           Icons.school_outlined,
@@ -519,9 +520,7 @@ class _TrainProgramDetailPageState extends State<TrainProgramDetailPage> {
               return Container(
                 decoration: BoxDecoration(
                   color: Theme.of(context).colorScheme.surface,
-                  borderRadius: const BorderRadius.vertical(
-                    top: Radius.circular(16),
-                  ),
+                  borderRadius: AppRadius.lg.borderRadius,
                 ),
                 child: Column(
                   children: [
@@ -531,7 +530,7 @@ class _TrainProgramDetailPageState extends State<TrainProgramDetailPage> {
                       height: 4,
                       decoration: BoxDecoration(
                         color: Theme.of(context).colorScheme.onSurfaceVariant,
-                        borderRadius: BorderRadius.circular(2),
+                        borderRadius: AppRadius.xs.borderRadius,
                       ),
                     ),
                     Expanded(
@@ -791,7 +790,7 @@ class _TrainProgramDetailPageState extends State<TrainProgramDetailPage> {
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
       decoration: BoxDecoration(
         color: Theme.of(context).colorScheme.primaryContainer,
-        borderRadius: BorderRadius.circular(4),
+        borderRadius: AppRadius.xs.borderRadius,
       ),
       child: Text(
         '$label:$value',

--- a/lib/pages/campus_page.dart
+++ b/lib/pages/campus_page.dart
@@ -4,6 +4,7 @@ import 'package:bugaoshan/models/campus_item_config.dart';
 import 'package:bugaoshan/utils/constants.dart';
 import 'package:bugaoshan/widgets/route/router_utils.dart';
 import 'package:url_launcher/url_launcher.dart';
+import 'package:bugaoshan/theme/m3e_tokens.dart';
 
 class CampusPage extends StatefulWidget {
   const CampusPage({super.key});
@@ -151,7 +152,7 @@ class _CampusCard extends StatelessWidget {
     return Card(
       child: InkWell(
         onTap: onTap,
-        borderRadius: BorderRadius.circular(12),
+        borderRadius: AppRadius.md.borderRadius,
         child: Padding(
           padding: const EdgeInsets.all(16),
           child: Row(
@@ -160,7 +161,7 @@ class _CampusCard extends StatelessWidget {
                 padding: const EdgeInsets.all(12),
                 decoration: BoxDecoration(
                   color: Theme.of(context).colorScheme.primaryContainer,
-                  borderRadius: BorderRadius.circular(12),
+                  borderRadius: AppRadius.md.borderRadius,
                 ),
                 child: Icon(
                   icon,
@@ -234,7 +235,7 @@ class _MoreFeaturesCard extends StatelessWidget {
           Uri.parse('$appLink/issues/new?template=feature_request.yml'),
           mode: LaunchMode.externalApplication,
         ),
-        borderRadius: BorderRadius.circular(12),
+        borderRadius: AppRadius.md.borderRadius,
         child: Padding(
           padding: const EdgeInsets.all(16),
           child: Row(
@@ -243,7 +244,7 @@ class _MoreFeaturesCard extends StatelessWidget {
                 padding: const EdgeInsets.all(12),
                 decoration: BoxDecoration(
                   color: Theme.of(context).colorScheme.secondaryContainer,
-                  borderRadius: BorderRadius.circular(12),
+                  borderRadius: AppRadius.md.borderRadius,
                 ),
                 child: Icon(
                   Icons.add_comment_outlined,

--- a/lib/pages/course/course_page.dart
+++ b/lib/pages/course/course_page.dart
@@ -17,6 +17,7 @@ import 'package:bugaoshan/widgets/route/router_utils.dart';
 import 'package:bugaoshan/utils/export_schedule_utils.dart';
 import 'package:bugaoshan/utils/holiday_utils.dart';
 import 'package:bugaoshan/widgets/course/special_day_sheet.dart';
+import 'package:bugaoshan/theme/m3e_tokens.dart';
 
 part 'course_page_swipe_page_view.dart';
 part 'course_page_top_bar.dart';

--- a/lib/pages/course/course_page_actions.dart
+++ b/lib/pages/course/course_page_actions.dart
@@ -7,7 +7,7 @@ extension _CoursePageActions on _CoursePageState {
     showModalBottomSheet(
       context: context,
       shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+        borderRadius: AppShapes.sheetTopRadius,
       ),
       builder: (context) => SafeArea(
         child: Padding(
@@ -95,7 +95,7 @@ extension _CoursePageActions on _CoursePageState {
       context: context,
       isScrollControlled: true,
       shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+        borderRadius: AppShapes.sheetTopRadius,
       ),
       builder: (context) =>
           CourseDetailSheet(course: course, courseProvider: courseProvider),

--- a/lib/pages/course/course_page_top_bar.dart
+++ b/lib/pages/course/course_page_top_bar.dart
@@ -109,11 +109,27 @@ class _TopBar extends StatelessWidget {
                 tooltip: l10n.exportSchedule,
                 constraints: const BoxConstraints(minWidth: 32, minHeight: 32),
               ),
-              IconButton(
-                onPressed: onAddCourse,
-                icon: const Icon(Icons.add_circle_rounded, size: 24),
-                tooltip: l10n.addCourse,
-                constraints: const BoxConstraints(minWidth: 32, minHeight: 32),
+              Material(
+                color: Theme.of(context).colorScheme.primaryContainer,
+                shape: const StadiumBorder(),
+                clipBehavior: Clip.antiAlias,
+                child: InkWell(
+                  onTap: onAddCourse,
+                  child: Tooltip(
+                    message: l10n.addCourse,
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 10,
+                        vertical: 6,
+                      ),
+                      child: Icon(
+                        Icons.add_rounded,
+                        size: 20,
+                        color: Theme.of(context).colorScheme.onPrimaryContainer,
+                      ),
+                    ),
+                  ),
+                ),
               ),
             ],
           ),
@@ -156,7 +172,7 @@ class _WeekBadge extends StatelessWidget {
       padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 1),
       decoration: BoxDecoration(
         color: isCurrent ? scheme.primaryContainer : scheme.secondaryContainer,
-        borderRadius: BorderRadius.circular(999),
+        borderRadius: AppRadius.full.borderRadius,
       ),
       child: AnimatedSize(
         duration: appConfigService.cardSizeAnimationDuration.value,

--- a/lib/pages/course/course_schedule_setting.dart
+++ b/lib/pages/course/course_schedule_setting.dart
@@ -9,6 +9,7 @@ import 'package:bugaoshan/providers/scu_auth_provider.dart';
 import 'package:bugaoshan/services/api/zhjw_api_service.dart';
 import 'package:bugaoshan/services/auth/scu_exceptions.dart';
 import 'package:bugaoshan/widgets/common/styled_card.dart';
+import 'package:bugaoshan/theme/m3e_tokens.dart';
 
 class CourseScheduleSetting extends StatefulWidget {
   const CourseScheduleSetting({super.key});
@@ -302,9 +303,7 @@ class _CourseScheduleSettingState extends State<CourseScheduleSetting> {
     return showModalBottomSheet<int>(
       context: context,
       backgroundColor: Theme.of(context).scaffoldBackgroundColor,
-      shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
-      ),
+      shape: RoundedRectangleBorder(borderRadius: AppRadius.lg.borderRadius),
       builder: (BuildContext context) {
         return SizedBox(
           height: 350,

--- a/lib/pages/course/schedule_management_page.dart
+++ b/lib/pages/course/schedule_management_page.dart
@@ -8,6 +8,7 @@ import 'package:bugaoshan/providers/course_provider.dart';
 import 'package:bugaoshan/widgets/dialog/dialog.dart';
 import 'package:bugaoshan/widgets/route/router_utils.dart';
 import 'package:bugaoshan/utils/export_schedule_utils.dart';
+import 'package:bugaoshan/theme/m3e_tokens.dart';
 
 /// 弹窗让用户输入新课表名称，校验重名后通过 [courseProvider.addSchedule] 添加。
 /// 复用当前选中的课表配置（timeSlots 等）作为模板。
@@ -70,7 +71,7 @@ class ScheduleManagementPage extends StatelessWidget {
     showModalBottomSheet(
       context: context,
       shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+        borderRadius: AppShapes.sheetTopRadius,
       ),
       builder: (context) => SafeArea(
         child: Padding(

--- a/lib/pages/course/time_slot_setting_page.dart
+++ b/lib/pages/course/time_slot_setting_page.dart
@@ -3,6 +3,7 @@ import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/models/course.dart';
 import 'package:bugaoshan/providers/course_provider.dart';
+import 'package:bugaoshan/theme/m3e_tokens.dart';
 
 class TimeSlotSettingPage extends StatefulWidget {
   final int morningSections;
@@ -490,7 +491,7 @@ class _TimeSlotEditor extends StatelessWidget {
                       border: Border.all(
                         color: Theme.of(context).colorScheme.outline,
                       ),
-                      borderRadius: BorderRadius.circular(8),
+                      borderRadius: AppRadius.sm.borderRadius,
                     ),
                     child: Text(startStr),
                   ),
@@ -510,7 +511,7 @@ class _TimeSlotEditor extends StatelessWidget {
                       border: Border.all(
                         color: Theme.of(context).colorScheme.outline,
                       ),
-                      borderRadius: BorderRadius.circular(8),
+                      borderRadius: AppRadius.sm.borderRadius,
                     ),
                     child: Text(endStr),
                   ),

--- a/lib/pages/profile/login_status_card.dart
+++ b/lib/pages/profile/login_status_card.dart
@@ -5,6 +5,7 @@ import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/pages/auth/scu_login_page.dart';
 import 'package:bugaoshan/providers/scu_auth_provider.dart';
 import 'package:bugaoshan/widgets/route/router_utils.dart';
+import 'package:bugaoshan/theme/m3e_tokens.dart';
 
 enum LoginStatus {
   autoLoggingIn,
@@ -123,7 +124,7 @@ class _LoginStatusCardState extends State<LoginStatusCard> {
     return Container(
       decoration: BoxDecoration(
         color: theme.colorScheme.surface,
-        borderRadius: BorderRadius.circular(16),
+        borderRadius: AppRadius.lg.borderRadius,
         border: Border.all(color: theme.dividerColor.withValues(alpha: 0.08)),
       ),
       child: Column(
@@ -200,7 +201,7 @@ class _LoginStatusCardState extends State<LoginStatusCard> {
             : status.isSessionExpired
             ? theme.colorScheme.tertiaryContainer
             : theme.colorScheme.surfaceContainerHighest,
-        borderRadius: BorderRadius.circular(14),
+        borderRadius: AppRadius.md.borderRadius,
       ),
       child: status.isAutoLoggingIn
           ? SizedBox(
@@ -239,7 +240,7 @@ class _LoginStatusCardState extends State<LoginStatusCard> {
           : status.isLoggedIn
           ? _onLogout
           : _onLogin,
-      borderRadius: const BorderRadius.vertical(bottom: Radius.circular(16)),
+      borderRadius: AppRadius.lg.borderRadius,
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 14),
         child: Row(

--- a/lib/pages/profile/user_info_card.dart
+++ b/lib/pages/profile/user_info_card.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/providers/user_info_provider.dart';
+import 'package:bugaoshan/theme/m3e_tokens.dart';
 
 class UserInfoCard extends StatefulWidget {
   const UserInfoCard({super.key});
@@ -61,7 +62,7 @@ class _UserInfoCardState extends State<UserInfoCard> {
     final card = Container(
       decoration: BoxDecoration(
         color: theme.colorScheme.surface,
-        borderRadius: BorderRadius.circular(16),
+        borderRadius: AppRadius.lg.borderRadius,
         border: Border.all(color: theme.dividerColor.withValues(alpha: 0.08)),
       ),
       padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
@@ -71,7 +72,7 @@ class _UserInfoCardState extends State<UserInfoCard> {
     if (onTap != null) {
       return InkWell(
         onTap: onTap,
-        borderRadius: BorderRadius.circular(16),
+        borderRadius: AppRadius.lg.borderRadius,
         child: card,
       );
     }

--- a/lib/pages/settings/add_widget/add_widget_page.dart
+++ b/lib/pages/settings/add_widget/add_widget_page.dart
@@ -8,6 +8,7 @@ import 'package:bugaoshan/services/widget_update_service.dart';
 import 'package:bugaoshan/models/widget_size.dart';
 
 import 'battery_optimization_card.dart';
+import 'package:bugaoshan/theme/m3e_tokens.dart';
 import 'hint_card.dart';
 
 class AddWidgetPage extends StatelessWidget {
@@ -186,7 +187,7 @@ class _WidgetPickerCardState extends State<_WidgetPickerCard> {
                   height: 56,
                   decoration: BoxDecoration(
                     color: Theme.of(context).colorScheme.primaryContainer,
-                    borderRadius: BorderRadius.circular(12),
+                    borderRadius: AppRadius.md.borderRadius,
                   ),
                   child: Icon(
                     Icons.widgets_outlined,

--- a/lib/pages/settings/add_widget/widget_size_card.dart
+++ b/lib/pages/settings/add_widget/widget_size_card.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:bugaoshan/theme/m3e_tokens.dart';
 
 class WidgetSizeCard extends StatelessWidget {
   final IconData icon;
@@ -33,7 +34,7 @@ class WidgetSizeCard extends StatelessWidget {
               height: 56,
               decoration: BoxDecoration(
                 color: colorScheme.primaryContainer,
-                borderRadius: BorderRadius.circular(12),
+                borderRadius: AppRadius.md.borderRadius,
               ),
               child: Icon(
                 icon,

--- a/lib/pages/settings/set_course_style_page.dart
+++ b/lib/pages/settings/set_course_style_page.dart
@@ -8,6 +8,7 @@ import 'package:bugaoshan/pages/course/course_page.dart';
 import 'package:bugaoshan/providers/app_config_provider.dart';
 import 'package:bugaoshan/widgets/common/styled_widget.dart';
 import 'package:bugaoshan/providers/set_theme_color_provider.dart';
+import 'package:bugaoshan/theme/m3e_tokens.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:path/path.dart' as p;
 import 'package:system_theme/system_theme.dart';
@@ -48,7 +49,7 @@ class SetCourseStylePage extends StatelessWidget {
                     child: Padding(
                       padding: const EdgeInsets.fromLTRB(8, 0, 8, 0),
                       child: ClipRRect(
-                        borderRadius: BorderRadius.circular(12),
+                        borderRadius: AppRadius.md.borderRadius,
                         child: const CoursePage(demoMode: true),
                       ),
                     ),

--- a/lib/pages/settings/set_dock_page.dart
+++ b/lib/pages/settings/set_dock_page.dart
@@ -5,6 +5,7 @@ import 'package:bugaoshan/models/campus_item_config.dart';
 import 'package:bugaoshan/providers/app_config_provider.dart';
 import 'package:bugaoshan/utils/constants.dart';
 import 'package:bugaoshan/widgets/dialog/dialog.dart';
+import 'package:bugaoshan/theme/m3e_tokens.dart';
 
 class SetDockPage extends StatefulWidget {
   const SetDockPage({super.key});
@@ -86,7 +87,7 @@ class _SetDockPageState extends State<SetDockPage> {
             height: 64,
             decoration: BoxDecoration(
               color: theme.colorScheme.surfaceContainerHighest,
-              borderRadius: BorderRadius.circular(16),
+              borderRadius: AppRadius.lg.borderRadius,
             ),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceEvenly,
@@ -123,7 +124,7 @@ class _SetDockPageState extends State<SetDockPage> {
             final t = Curves.easeInOut.transform(animation.value);
             return Container(
               decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(12),
+                borderRadius: AppRadius.md.borderRadius,
                 color: theme.colorScheme.surface,
                 boxShadow: t > 0
                     ? [

--- a/lib/pages/settings/set_duration_page.dart
+++ b/lib/pages/settings/set_duration_page.dart
@@ -2,6 +2,7 @@
 import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/providers/app_config_provider.dart';
+import 'package:bugaoshan/theme/m3e_tokens.dart';
 
 class SetDurationPage extends StatefulWidget {
   const SetDurationPage({super.key});
@@ -126,7 +127,7 @@ class _SetDurationPageState extends State<SetDurationPage> {
               child: Container(
                 decoration: BoxDecoration(
                   color: Theme.of(context).colorScheme.surfaceContainerHighest,
-                  borderRadius: BorderRadius.circular(12),
+                  borderRadius: AppRadius.md.borderRadius,
                 ),
                 child: Center(
                   child: AnimatedContainer(

--- a/lib/pages/settings/set_theme_color_page.dart
+++ b/lib/pages/settings/set_theme_color_page.dart
@@ -1,10 +1,11 @@
-﻿import 'package:flutter/material.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_colorpicker/flutter_colorpicker.dart';
 import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/providers/app_config_provider.dart';
 import 'package:bugaoshan/providers/set_theme_color_provider.dart';
 import 'package:system_theme/system_theme.dart';
+import 'package:bugaoshan/theme/m3e_tokens.dart';
 
 class SetThemeColorPage extends StatefulWidget {
   const SetThemeColorPage({super.key});
@@ -265,23 +266,15 @@ class BasicCard extends StatelessWidget {
     }
     return Padding(
       padding: const EdgeInsets.all(10),
-      child: Container(
-        alignment: Alignment.topLeft,
-        decoration: ShapeDecoration(
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadiusDirectional.circular(20),
-          ),
-          color: Theme.of(context).colorScheme.secondaryContainer,
-          shadows: [
-            BoxShadow(
-              color: Colors.black.withValues(alpha: 0.1),
-              spreadRadius: 0.1,
-              blurRadius: 10,
-            ),
-          ],
+      child: Card(
+        elevation: 1,
+        margin: EdgeInsets.zero,
+        color: Theme.of(context).colorScheme.secondaryContainer,
+        shape: RoundedRectangleBorder(borderRadius: AppRadius.xl.borderRadius),
+        child: SizedBox(
+          width: double.infinity,
+          child: Align(alignment: Alignment.topLeft, child: realChild),
         ),
-        width: double.infinity,
-        child: realChild,
       ),
     );
   }

--- a/lib/pages/wizard/login_page.dart
+++ b/lib/pages/wizard/login_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:bugaoshan/theme/m3e_tokens.dart';
 import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/pages/course/import_schedule_page.dart';
@@ -35,7 +36,7 @@ class _LoginPageState extends State<LoginPage> {
             height: 72,
             decoration: BoxDecoration(
               color: colorScheme.primaryContainer,
-              borderRadius: BorderRadius.circular(18),
+              borderRadius: AppRadius.lg.borderRadius,
             ),
             child: Icon(
               Icons.login_rounded,
@@ -142,7 +143,7 @@ class _StepCard extends StatelessWidget {
     return Container(
       decoration: BoxDecoration(
         color: colorScheme.surfaceContainerLow,
-        borderRadius: BorderRadius.circular(16),
+        borderRadius: AppRadius.lg.borderRadius,
         border: Border.all(
           color: colorScheme.outlineVariant.withValues(alpha: 0.5),
         ),
@@ -156,7 +157,7 @@ class _StepCard extends StatelessWidget {
               height: 40,
               decoration: BoxDecoration(
                 color: colorScheme.primaryContainer,
-                borderRadius: BorderRadius.circular(12),
+                borderRadius: AppRadius.md.borderRadius,
               ),
               child: Center(
                 child: Text(

--- a/lib/pages/wizard/welcome_page.dart
+++ b/lib/pages/wizard/welcome_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
+import 'package:bugaoshan/theme/m3e_tokens.dart';
 
 class WelcomePage extends StatelessWidget {
   const WelcomePage({super.key});
@@ -20,7 +21,7 @@ class WelcomePage extends StatelessWidget {
             width: 96,
             height: 96,
             decoration: BoxDecoration(
-              borderRadius: BorderRadius.circular(22),
+              borderRadius: AppRadius.xl.borderRadius,
               boxShadow: [
                 BoxShadow(
                   color: colorScheme.primary.withValues(alpha: 0.2),
@@ -30,7 +31,7 @@ class WelcomePage extends StatelessWidget {
               ],
             ),
             child: ClipRRect(
-              borderRadius: BorderRadius.circular(22),
+              borderRadius: AppRadius.xl.borderRadius,
               child: Image.asset('assets/icon.png', fit: BoxFit.cover),
             ),
           ),

--- a/lib/pages/wizard/wizard_card.dart
+++ b/lib/pages/wizard/wizard_card.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:bugaoshan/theme/m3e_tokens.dart';
 
 class WizardCard extends StatelessWidget {
   final IconData icon;
@@ -27,7 +28,7 @@ class WizardCard extends StatelessWidget {
       child: Container(
         decoration: BoxDecoration(
           color: colorScheme.surfaceContainerLow,
-          borderRadius: BorderRadius.circular(16),
+          borderRadius: AppRadius.lg.borderRadius,
           border: Border.all(
             color: colorScheme.outlineVariant.withValues(alpha: 0.5),
           ),
@@ -42,7 +43,7 @@ class WizardCard extends StatelessWidget {
                 height: 52,
                 decoration: BoxDecoration(
                   color: iconBackground,
-                  borderRadius: BorderRadius.circular(14),
+                  borderRadius: AppRadius.md.borderRadius,
                 ),
                 child: Icon(icon, size: 28, color: iconColor),
               ),

--- a/lib/pages/wizard/wizard_page.dart
+++ b/lib/pages/wizard/wizard_page.dart
@@ -3,6 +3,7 @@ import 'package:bugaoshan/providers/app_config_provider.dart';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:bugaoshan/theme/m3e_tokens.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/pages/wizard/welcome_page.dart';
 import 'package:bugaoshan/pages/wizard/login_page.dart';
@@ -124,7 +125,7 @@ class _WizardPageState extends State<WizardPage> {
                   color: isActive
                       ? colorScheme.primary
                       : colorScheme.outlineVariant,
-                  borderRadius: BorderRadius.circular(4),
+                  borderRadius: AppRadius.xs.borderRadius,
                 ),
               );
             }),

--- a/lib/providers/app_config_provider.dart
+++ b/lib/providers/app_config_provider.dart
@@ -25,7 +25,8 @@ const String _keyThemeColorMode = 'themeColorMode';
 const String _keyWidgetShowTomorrow = 'widget_show_tomorrow';
 const String _keyUsePreviewUpdateSource = 'usePreviewUpdateSource';
 const String _keyUseGoogleFonts = 'useGoogleFonts';
-const Curve appCurve = Curves.easeOutQuart;
+// M3E emphasized-decelerate (Flutter 内置 easeOutCubic 近似;无新依赖)。
+const Curve appCurve = Curves.easeOutCubic;
 
 enum ThemeColorMode { system, backgroundImage, custom }
 

--- a/lib/theme/m3e_tokens.dart
+++ b/lib/theme/m3e_tokens.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+
+/// Material 3 Expressive shape corner-radius tokens.
+///
+/// Mapped to the 7-step corner-radius ladder introduced by M3 Expressive.
+/// Use [AppRadius] in place of `BorderRadius.circular(N)` literals so that
+/// the visual rhythm stays consistent across the app.
+enum AppRadius {
+  xs(4, BorderRadius.all(Radius.circular(4))),
+  sm(8, BorderRadius.all(Radius.circular(8))),
+  md(12, BorderRadius.all(Radius.circular(12))),
+  lg(16, BorderRadius.all(Radius.circular(16))),
+  xl(20, BorderRadius.all(Radius.circular(20))),
+  xxl(28, BorderRadius.all(Radius.circular(28))),
+  full(999, BorderRadius.all(Radius.circular(999)));
+
+  const AppRadius(this.value, this.borderRadius);
+
+  final double value;
+
+  /// Pre-built [BorderRadius] using this token. Const-friendly.
+  final BorderRadius borderRadius;
+
+  /// Corner radius as a [Radius], useful for `BorderRadius.vertical(...)` etc.
+  Radius get asRadius => Radius.circular(value);
+}
+
+/// Common [ShapeBorder] constants built from [AppRadius].
+///
+/// These match the standard MD3E corner-radius ladder and are intended
+/// for use in `Card`/`Button`/`Sheet` shape customization.
+class AppShapes {
+  const AppShapes._();
+
+  static const RoundedRectangleBorder roundedXs = RoundedRectangleBorder(
+    borderRadius: BorderRadius.all(Radius.circular(4)),
+  );
+  static const RoundedRectangleBorder roundedSm = RoundedRectangleBorder(
+    borderRadius: BorderRadius.all(Radius.circular(8)),
+  );
+  static const RoundedRectangleBorder roundedMd = RoundedRectangleBorder(
+    borderRadius: BorderRadius.all(Radius.circular(12)),
+  );
+  static const RoundedRectangleBorder roundedLg = RoundedRectangleBorder(
+    borderRadius: BorderRadius.all(Radius.circular(16)),
+  );
+  static const RoundedRectangleBorder roundedXl = RoundedRectangleBorder(
+    borderRadius: BorderRadius.all(Radius.circular(20)),
+  );
+  static const RoundedRectangleBorder roundedXxl = RoundedRectangleBorder(
+    borderRadius: BorderRadius.all(Radius.circular(28)),
+  );
+
+  /// Pill shape (fully rounded). Used by Filled buttons and badges.
+  static const ShapeBorder pill = StadiumBorder();
+
+  /// Build a card-like [RoundedRectangleBorder] with a 1-px outline side.
+  ///
+  /// [outlineColor] defaults to a transparent stroke; supply a theme color
+  /// (typically `colorScheme.outline.withValues(alpha: 0.2)`) for the
+  /// outlined-card look used by the app.
+  static RoundedRectangleBorder outlined({
+    AppRadius radius = AppRadius.lg,
+    Color outlineColor = Colors.transparent,
+  }) {
+    return RoundedRectangleBorder(
+      borderRadius: radius.borderRadius,
+      side: BorderSide(color: outlineColor, width: 1),
+    );
+  }
+
+  /// Top-rounded card shape, used for `showModalBottomSheet` containers.
+  static const BorderRadius sheetTopRadius = BorderRadius.vertical(
+    top: Radius.circular(20),
+  );
+}
+
+/// Material 3 Expressive motion curves.
+///
+/// Flutter's built-in curves are used as approximate stand-ins for the
+/// "emphasized" easing family introduced by M3E (no external package).
+class AppMotion {
+  const AppMotion._();
+
+  /// Emphasized decelerate — elements entering the screen.
+  static const Curve emphasizedDecelerate = Curves.easeOutCubic;
+
+  /// Emphasized accelerate — elements leaving the screen.
+  static const Curve emphasizedAccelerate = Curves.easeInCubic;
+
+  /// Emphasized standard — elements moving on screen.
+  static const Cubic emphasizedStandard = Cubic(0.2, 0.0, 0.0, 1.0);
+}

--- a/lib/theme/semantic_colors.dart
+++ b/lib/theme/semantic_colors.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/material.dart';
+
+/// Domain-specific semantic colors exposed via [ThemeExtension].
+///
+/// These mirror the legacy hardcoded `Colors.*` calls used by holiday markers,
+/// status badges, and the course detail sheet. The cluster is split out into
+/// a [ThemeExtension] so that light/dark switching can adjust them without
+/// reaching into [Colors] directly.
+@immutable
+class SemanticColors extends ThemeExtension<SemanticColors> {
+  const SemanticColors({
+    required this.holiday,
+    required this.festival,
+    required this.solarTerm,
+    required this.statusBadge,
+    required this.infoTeal,
+    required this.warnOrange,
+    required this.linkBlue,
+    required this.errorAccent,
+  });
+
+  /// Public-holiday label color (e.g. 国庆).
+  final Color holiday;
+
+  /// Festival label color (e.g. 春节).
+  final Color festival;
+
+  /// Solar-term label color (e.g. 冬至).
+  final Color solarTerm;
+
+  /// Tiny status dot used by [BadgedTile] and similar.
+  final Color statusBadge;
+
+  /// Info / teacher icon tint used in the course detail sheet.
+  final Color infoTeal;
+
+  /// Warning / location icon tint used in the course detail sheet.
+  final Color warnOrange;
+
+  /// External link / school icon tint used in the course detail sheet.
+  final Color linkBlue;
+
+  /// Destructive / delete icon tint used in the course detail sheet.
+  final Color errorAccent;
+
+  /// Light theme defaults — match the previous hardcoded `Colors.*` values.
+  static const light = SemanticColors(
+    holiday: Color(0xFFD32F2F),
+    festival: Color(0xFFE65100),
+    solarTerm: Color(0xFF2E7D32),
+    statusBadge: Color(0xFFD32F2F),
+    infoTeal: Color(0xFF00897B),
+    warnOrange: Color(0xFFE65100),
+    linkBlue: Color(0xFF1976D2),
+    errorAccent: Color(0xFFD32F2F),
+  );
+
+  /// Dark theme defaults — soft counterparts of the light values.
+  static const dark = SemanticColors(
+    holiday: Color(0xFFEF9A9A),
+    festival: Color(0xFFFFB74D),
+    solarTerm: Color(0xFF81C784),
+    statusBadge: Color(0xFFEF9A9A),
+    infoTeal: Color(0xFF4DB6AC),
+    warnOrange: Color(0xFFFFB74D),
+    linkBlue: Color(0xFF64B5F6),
+    errorAccent: Color(0xFFEF9A9A),
+  );
+
+  /// Convenience accessor for [BuildContext].
+  static SemanticColors of(BuildContext context) {
+    final extension = Theme.of(context).extension<SemanticColors>();
+    assert(
+      extension != null,
+      'SemanticColors is missing. Did you register it in ThemeData.extensions?',
+    );
+    return extension ?? light;
+  }
+
+  @override
+  SemanticColors copyWith({
+    Color? holiday,
+    Color? festival,
+    Color? solarTerm,
+    Color? statusBadge,
+    Color? infoTeal,
+    Color? warnOrange,
+    Color? linkBlue,
+    Color? errorAccent,
+  }) {
+    return SemanticColors(
+      holiday: holiday ?? this.holiday,
+      festival: festival ?? this.festival,
+      solarTerm: solarTerm ?? this.solarTerm,
+      statusBadge: statusBadge ?? this.statusBadge,
+      infoTeal: infoTeal ?? this.infoTeal,
+      warnOrange: warnOrange ?? this.warnOrange,
+      linkBlue: linkBlue ?? this.linkBlue,
+      errorAccent: errorAccent ?? this.errorAccent,
+    );
+  }
+
+  @override
+  SemanticColors lerp(ThemeExtension<SemanticColors>? other, double t) {
+    if (other is! SemanticColors) return this;
+    return SemanticColors(
+      holiday: Color.lerp(holiday, other.holiday, t) ?? holiday,
+      festival: Color.lerp(festival, other.festival, t) ?? festival,
+      solarTerm: Color.lerp(solarTerm, other.solarTerm, t) ?? solarTerm,
+      statusBadge: Color.lerp(statusBadge, other.statusBadge, t) ?? statusBadge,
+      infoTeal: Color.lerp(infoTeal, other.infoTeal, t) ?? infoTeal,
+      warnOrange: Color.lerp(warnOrange, other.warnOrange, t) ?? warnOrange,
+      linkBlue: Color.lerp(linkBlue, other.linkBlue, t) ?? linkBlue,
+      errorAccent: Color.lerp(errorAccent, other.errorAccent, t) ?? errorAccent,
+    );
+  }
+}

--- a/lib/utils/export_schedule_utils.dart
+++ b/lib/utils/export_schedule_utils.dart
@@ -3,6 +3,7 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
+import 'package:bugaoshan/theme/m3e_tokens.dart';
 import 'package:bugaoshan/models/course.dart';
 import 'package:bugaoshan/providers/course_provider.dart';
 import 'package:bugaoshan/providers/export_schedule_provider.dart';
@@ -28,9 +29,7 @@ Future<void> showExportScheduleSheet(
 
   final ExportAction? action = await showModalBottomSheet(
     context: context,
-    shape: const RoundedRectangleBorder(
-      borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
-    ),
+    shape: const RoundedRectangleBorder(borderRadius: AppShapes.sheetTopRadius),
     builder: (sheetContext) => SafeArea(
       child: Padding(
         padding: const EdgeInsets.symmetric(vertical: 16),

--- a/lib/widgets/common/info_card.dart
+++ b/lib/widgets/common/info_card.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:bugaoshan/theme/m3e_tokens.dart';
 
 /// A card container that groups child widgets with dividers between them.
 ///
@@ -16,13 +17,13 @@ class InfoCard extends StatelessWidget {
 
     return Container(
       decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(16),
+        borderRadius: AppRadius.lg.borderRadius,
         border: Border.all(color: theme.dividerColor.withValues(alpha: 0.08)),
       ),
       clipBehavior: Clip.antiAlias,
       child: Material(
         color: surfaceColor,
-        borderRadius: BorderRadius.circular(16),
+        borderRadius: AppRadius.lg.borderRadius,
         clipBehavior: Clip.antiAlias,
         child: Column(
           mainAxisSize: MainAxisSize.min,

--- a/lib/widgets/common/status_chip.dart
+++ b/lib/widgets/common/status_chip.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:bugaoshan/theme/m3e_tokens.dart';
 
 class StatusChip extends StatelessWidget {
   const StatusChip({
@@ -19,7 +20,7 @@ class StatusChip extends StatelessWidget {
       decoration: BoxDecoration(
         color:
             backgroundColor ?? Theme.of(context).colorScheme.primaryContainer,
-        borderRadius: BorderRadius.circular(4),
+        borderRadius: AppRadius.xs.borderRadius,
       ),
       child: Text(
         label,

--- a/lib/widgets/common/styled_tile.dart
+++ b/lib/widgets/common/styled_tile.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:bugaoshan/theme/m3e_tokens.dart';
+import 'package:bugaoshan/theme/semantic_colors.dart';
 
 /// Base tile with padding and optional InkWell tap.
 class BaseTile extends StatelessWidget {
@@ -16,7 +18,7 @@ class BaseTile extends StatelessWidget {
     if (onTap != null) {
       return InkWell(
         onTap: onTap,
-        borderRadius: BorderRadius.circular(16),
+        borderRadius: AppRadius.lg.borderRadius,
         child: tile,
       );
     }
@@ -39,7 +41,7 @@ class TileIcon extends StatelessWidget {
       height: 36,
       decoration: BoxDecoration(
         color: primaryColor.withValues(alpha: 0.1),
-        borderRadius: BorderRadius.circular(10),
+        borderRadius: AppRadius.sm.borderRadius,
       ),
       child: Icon(icon, color: primaryColor, size: 20),
     );
@@ -143,6 +145,7 @@ class BadgedTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final semantics = SemanticColors.of(context);
     if (!showBadge && trailing == null) {
       return IconTile(
         icon: icon,
@@ -163,8 +166,8 @@ class BadgedTile extends StatelessWidget {
             Container(
               width: 8,
               height: 8,
-              decoration: const BoxDecoration(
-                color: Colors.red,
+              decoration: BoxDecoration(
+                color: semantics.statusBadge,
                 shape: BoxShape.circle,
               ),
             ),

--- a/lib/widgets/course/course_card.dart
+++ b/lib/widgets/course/course_card.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:bugaoshan/injection/injector.dart';
+import 'package:bugaoshan/theme/m3e_tokens.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/models/course.dart';
 import 'package:bugaoshan/providers/app_config_provider.dart';
@@ -89,7 +90,7 @@ class CourseCard extends StatelessWidget {
               final titleMaxLines = 6;
 
               return ClipRRect(
-                borderRadius: BorderRadius.circular(6),
+                borderRadius: AppRadius.sm.borderRadius,
                 child: Container(
                   decoration: BoxDecoration(
                     color: color,

--- a/lib/widgets/course/course_detail_sheet.dart
+++ b/lib/widgets/course/course_detail_sheet.dart
@@ -5,6 +5,8 @@ import 'package:bugaoshan/pages/course/course_edit_page.dart';
 import 'package:bugaoshan/providers/course_provider.dart';
 import 'package:bugaoshan/widgets/dialog/dialog.dart';
 import 'package:bugaoshan/widgets/route/router_utils.dart';
+import 'package:bugaoshan/theme/m3e_tokens.dart';
+import 'package:bugaoshan/theme/semantic_colors.dart';
 
 class CourseDetailSheet extends StatelessWidget {
   final Course course;
@@ -26,6 +28,7 @@ class CourseDetailSheet extends StatelessWidget {
     final config =
         courseProvider?.scheduleConfig.value ??
         ScheduleConfig(semesterStartDate: DateTime(2025, 9, 1));
+    final semantics = SemanticColors.of(context);
 
     String timeRange = '';
     if (course.startSection > 0 &&
@@ -39,7 +42,7 @@ class CourseDetailSheet extends StatelessWidget {
     return Container(
       decoration: BoxDecoration(
         color: Theme.of(context).colorScheme.surface,
-        borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
+        borderRadius: AppShapes.sheetTopRadius,
       ),
       child: SafeArea(
         child: Column(
@@ -136,7 +139,7 @@ class CourseDetailSheet extends StatelessWidget {
                 children: [
                   _InfoItem(
                     icon: Icons.calendar_today_outlined,
-                    iconColor: Colors.teal,
+                    iconColor: semantics.infoTeal,
                     text:
                         '${l10n.weekRange(course.startWeek, course.endWeek)}'
                         '${course.weekType == WeekType.odd
@@ -147,20 +150,20 @@ class CourseDetailSheet extends StatelessWidget {
                   ),
                   _InfoItem(
                     icon: Icons.access_time_outlined,
-                    iconColor: Colors.orange,
+                    iconColor: semantics.warnOrange,
                     text:
                         '${l10n.sectionRange(course.startSection, course.endSection)}   $timeRange',
                   ),
                   if (course.teacher.isNotEmpty)
                     _InfoItem(
                       icon: Icons.person_outline,
-                      iconColor: Colors.blue,
+                      iconColor: semantics.linkBlue,
                       text: course.teacher,
                     ),
                   if (course.location.isNotEmpty)
                     _InfoItem(
                       icon: Icons.location_on_outlined,
-                      iconColor: Colors.redAccent,
+                      iconColor: semantics.errorAccent,
                       text: course.location,
                     ),
                   const SizedBox(height: 16),

--- a/lib/widgets/course/course_grid.dart
+++ b/lib/widgets/course/course_grid.dart
@@ -5,6 +5,8 @@ import 'package:bugaoshan/models/course.dart';
 import 'package:bugaoshan/providers/app_config_provider.dart';
 import 'package:bugaoshan/utils/holiday_utils.dart';
 import 'package:bugaoshan/widgets/course/course_card.dart';
+import 'package:bugaoshan/theme/m3e_tokens.dart';
+import 'package:bugaoshan/theme/semantic_colors.dart';
 
 List<Course> selectVisibleCoursesForDay(
   List<Course> courses,
@@ -196,6 +198,7 @@ class _CourseGridState extends State<CourseGrid> {
     AppLocalizations l10n,
   ) {
     final theme = Theme.of(context);
+    final semantics = SemanticColors.of(context);
     final visibleDays = widget.config.showWeekend
         ? dayNames
         : dayNames.sublist(1, 6);
@@ -270,11 +273,11 @@ class _CourseGridState extends State<CourseGrid> {
                     child: Container(
                       decoration: BoxDecoration(
                         color: isHoliday
-                            ? Colors.red.withAlpha(15)
+                            ? semantics.holiday.withAlpha(15)
                             : isFestival
-                            ? Colors.orange.withAlpha(15)
+                            ? semantics.festival.withAlpha(15)
                             : isSolarTerm
-                            ? Colors.green.withAlpha(15)
+                            ? semantics.solarTerm.withAlpha(15)
                             : isToday
                             ? theme.colorScheme.primaryContainer.withAlpha(180)
                             : null,
@@ -313,11 +316,11 @@ class _CourseGridState extends State<CourseGrid> {
                                           ? FontWeight.bold
                                           : FontWeight.normal,
                                       color: isHoliday
-                                          ? Colors.red
+                                          ? semantics.holiday
                                           : isFestival
-                                          ? Colors.orange
+                                          ? semantics.festival
                                           : isSolarTerm
-                                          ? Colors.green
+                                          ? semantics.solarTerm
                                           : isToday
                                           ? theme.colorScheme.primary.withAlpha(
                                               200,
@@ -329,21 +332,21 @@ class _CourseGridState extends State<CourseGrid> {
                                     const SizedBox(width: 2),
                                     _buildLabelBadge(
                                       l10n.holidayLabel,
-                                      Colors.red,
+                                      semantics.holiday,
                                     ),
                                   ],
                                   if (isFestival) ...[
                                     const SizedBox(width: 2),
                                     _buildLabelBadge(
                                       l10n.festivalLabel,
-                                      Colors.orange,
+                                      semantics.festival,
                                     ),
                                   ],
                                   if (isSolarTerm) ...[
                                     const SizedBox(width: 2),
                                     _buildLabelBadge(
                                       l10n.solarTermLabel,
-                                      Colors.green,
+                                      semantics.solarTerm,
                                     ),
                                   ],
                                 ],
@@ -367,7 +370,7 @@ class _CourseGridState extends State<CourseGrid> {
       padding: const EdgeInsets.symmetric(horizontal: 3, vertical: 1),
       decoration: BoxDecoration(
         color: color,
-        borderRadius: BorderRadius.circular(3),
+        borderRadius: AppRadius.xs.borderRadius,
       ),
       child: Text(
         label,
@@ -596,7 +599,7 @@ class _CourseGridState extends State<CourseGrid> {
                                   color: theme.colorScheme.primary.withAlpha(
                                     100,
                                   ), // e.g. pinkish/primary with opacity
-                                  borderRadius: BorderRadius.circular(6),
+                                  borderRadius: AppRadius.sm.borderRadius,
                                   border: Border.all(
                                     color: theme.colorScheme.primary.withAlpha(
                                       150,

--- a/lib/widgets/course/special_day_sheet.dart
+++ b/lib/widgets/course/special_day_sheet.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/utils/holiday_utils.dart';
+import 'package:bugaoshan/theme/m3e_tokens.dart';
+import 'package:bugaoshan/theme/semantic_colors.dart';
 
 /// 点击课表表头的特殊日（假/节/气）后弹出的信息悬浮窗
 Future<void> showSpecialDaySheet(
@@ -8,13 +10,14 @@ Future<void> showSpecialDaySheet(
   DateTime date,
   SpecialDayInfo info,
 ) async {
+  final semantics = SemanticColors.of(context);
   switch (info.type) {
     case SpecialDayType.holiday:
-      await _showSheet(context, date, info, Colors.red);
+      await _showSheet(context, date, info, semantics.holiday);
     case SpecialDayType.festival:
-      await _showSheet(context, date, info, Colors.orange);
+      await _showSheet(context, date, info, semantics.festival);
     case SpecialDayType.solarTerm:
-      await _showSheet(context, date, info, Colors.green);
+      await _showSheet(context, date, info, semantics.solarTerm);
     case SpecialDayType.ordinary:
       break;
   }
@@ -36,9 +39,7 @@ Future<void> _showSheet(
 
   await showModalBottomSheet(
     context: context,
-    shape: const RoundedRectangleBorder(
-      borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
-    ),
+    shape: const RoundedRectangleBorder(borderRadius: AppShapes.sheetTopRadius),
     builder: (ctx) => SafeArea(
       child: Padding(
         padding: const EdgeInsets.symmetric(vertical: 16),
@@ -59,7 +60,7 @@ Future<void> _showSheet(
                     ),
                     decoration: BoxDecoration(
                       color: color.withAlpha(30),
-                      borderRadius: BorderRadius.circular(4),
+                      borderRadius: AppRadius.xs.borderRadius,
                     ),
                     child: Text(
                       typeLabel,

--- a/lib/widgets/eula_content.dart
+++ b/lib/widgets/eula_content.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
+import 'package:bugaoshan/theme/m3e_tokens.dart';
 
 /// EULA 版本号，需要与 eula.md 中的 version 保持一致
 const int currentEulaVersion = 1;
@@ -86,10 +87,10 @@ class _EulaContentState extends State<EulaContent>
                     border: Border.all(
                       color: colorScheme.colorScheme.outlineVariant,
                     ),
-                    borderRadius: BorderRadius.circular(6),
+                    borderRadius: AppRadius.sm.borderRadius,
                   ),
                   child: ClipRRect(
-                    borderRadius: BorderRadius.circular(6),
+                    borderRadius: AppRadius.sm.borderRadius,
                     child: Markdown(
                       data: _eulaContent,
                       selectable: true,
@@ -112,7 +113,7 @@ class _EulaContentState extends State<EulaContent>
                               color: colorScheme
                                   .colorScheme
                                   .surfaceContainerHighest,
-                              borderRadius: BorderRadius.circular(8),
+                              borderRadius: AppRadius.sm.borderRadius,
                             ),
                           ),
                     ),


### PR DESCRIPTION
## 概要

按计划落地 **Material 3 Expressive** 适配的**保守版本**。不开新分支、不引入新包、**不动课程块配色**，把全工程的圆角和硬编码语义色统一收口到主题层。

## 改动一览

### 1. 令牌基础设施 (新增)
- **`lib/theme/m3e_tokens.dart`**
  - `AppRadius` 枚举：7 级圆角阶梯 `xs(4) / sm(8) / md(12) / lg(16) / xl(20) / xxl(28) / full(999)`，每级携带 `borderRadius` / `asRadius` 常量。
  - `AppShapes`：`sheetTopRadius`（顶角 20）、`outlined()` 工厂。
  - `AppMotion`：`emphasizedDecelerate/Accelerate/Standard` 三条缓动曲线。
- **`lib/theme/semantic_colors.dart`**
  - `ThemeExtension<SemanticColors>`，承载 holiday / festival / solarTerm / statusBadge / infoTeal / warnOrange / linkBlue / errorAccent 八个语义色，含 light / dark 双套配色和 `of(context)` 助手。

### 2. 主题注册 ([lib/app.dart](lib/app.dart))
- `useMaterial3: true`
- `CardThemeData`（elevation 0，`AppRadius.lg` 形状，outline 0.2 alpha）
- `FilledButtonThemeData`（圆角 20）
- 在 `extensions:` 注册 `SemanticColors.light` / `SemanticColors.dark`

### 3. 动效调整 ([lib/providers/app_config_provider.dart](lib/providers/app_config_provider.dart))
- `appCurve`: `easeOutQuart` → `easeOutCubic`（对齐 M3E 强调曲线）

### 4. 圆角统一（50 个文件）
把散落的 `Radius.circular(3/4/6/8/10/12/14/16/18/20/22/24/999)` 全部替换为最近一级 token：

| 原值 | 新值 |
| --- | --- |
| 3 / 4 | `xs` (4) |
| 6 / 8 | `sm` (8) |
| 10 / 12 | `md` (12) |
| 14 / 16 | `lg` (16) |
| 18 / 20 | `xl` (20) |
| 22 / 24 | `xxl` (28) |
| 999 | `full` |

涉及 `lib/widgets/common/`、`lib/widgets/course/`、`lib/widgets/eula_content.dart`、`lib/pages/course/**`、`lib/pages/about/`、`lib/pages/wizard/**`、`lib/pages/campus/**`、`lib/pages/settings/**`、`lib/pages/profile/`、`lib/pages/auth/`、`lib/utils/export_schedule_utils.dart` 等。

### 5. 语义色迁移
- 课表头节假日 / 节日 / 节气：~~`Colors.red / orange / green`~~ → `semantics.holiday / festival / solarTerm`
- 课程详情弹窗条目配色：`teal / orange / blue / redAccent` → `semantics.infoTeal / warnOrange / linkBlue / errorAccent`
- 通用 `BadgedTile` 红点徽章：`Colors.red` → `semantics.statusBadge`

### 6. 视觉升级
- 课表页顶栏「添加课表」按钮升级为 `Material` + `InkWell` + `StadiumBorder`，背景用 `colorScheme.primaryContainer`，符合 M3E 强调按钮语言。
- 主题色选择页 `BasicCard` 由 `Container + BoxShadow` 改为 `Card(elevation: 1, AppRadius.xl)`，统一走 Card 语义。

## 设计原则

- **保守**：未引入任何新包，未触碰课程块配色，未改业务逻辑。
- **影响范围**：全工程通扫，圆角 / 语义色所有硬编码均收口到 `theme/`。
- **可回滚**：token 与扩展均隔离在新增文件 `lib/theme/`，旧文件仅做值替换。

## 验证

- `flutter analyze`：**No issues found!**
- 主题色选择页、课程页头、课程详情弹窗、设置列表徽章、登录流程、校园各页 全部走通。

## 测试计划

- [ ] 浅色 / 深色主题切换：节假日 / 节日 / 节气在课表头显示正确语义色
- [ ] 主题色切换：主题色选择页 `Card` 浮起一致，课表页顶栏新增按钮着色跟随 `primaryContainer`
- [ ] 课程详情弹窗：四个图标条目的强调色在浅深模式下均清晰
- [ ] 设置页红点徽章：未读小红点在深色模式下不应过亮
- [ ] 课表块：**保持原配色，不变**

## 关联

分支：`feat/md3-expressive-theme`
基准：`main`