### PR TITLE
feat: 适配 MD3 Expressive 形状令牌

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -9,6 +9,7 @@ import 'package:bugaoshan/pages/wizard/eula_gate_page.dart';
 import 'package:bugaoshan/pages/wizard/wizard_page.dart';
 import 'package:bugaoshan/providers/app_config_provider.dart';
 import 'package:bugaoshan/services/background_cache_service.dart';
+import 'package:bugaoshan/utils/app_shapes.dart';
 import 'package:bugaoshan/widgets/common/session_expired_listener.dart';
 import 'package:bugaoshan/widgets/eula_content.dart';
 import 'package:bugaoshan/widgets/route/mouse_back_handler.dart';
@@ -34,6 +35,51 @@ const _appBarTheme = AppBarTheme(
 );
 
 const _navigationBarTheme = NavigationBarThemeData(height: 64);
+
+/// MD3 Expressive 组件形状覆盖
+const _cardTheme = CardThemeData(
+  shape: RoundedRectangleBorder(
+    borderRadius: BorderRadius.all(Radius.circular(AppShapes.largeIncreased)),
+  ),
+);
+
+const _dialogTheme = DialogThemeData(
+  shape: RoundedRectangleBorder(
+    borderRadius: BorderRadius.all(Radius.circular(AppShapes.extraLarge)),
+  ),
+);
+
+const _bottomSheetTheme = BottomSheetThemeData(
+  shape: RoundedRectangleBorder(
+    borderRadius: BorderRadius.vertical(
+      top: Radius.circular(AppShapes.extraLarge),
+    ),
+  ),
+);
+
+const _chipTheme = ChipThemeData(shape: StadiumBorder());
+
+const _filledButtonTheme = FilledButtonThemeData(
+  style: ButtonStyle(shape: WidgetStatePropertyAll(StadiumBorder())),
+);
+
+const _elevatedButtonTheme = ElevatedButtonThemeData(
+  style: ButtonStyle(shape: WidgetStatePropertyAll(StadiumBorder())),
+);
+
+const _outlinedButtonTheme = OutlinedButtonThemeData(
+  style: ButtonStyle(shape: WidgetStatePropertyAll(StadiumBorder())),
+);
+
+const _textButtonTheme = TextButtonThemeData(
+  style: ButtonStyle(shape: WidgetStatePropertyAll(StadiumBorder())),
+);
+
+const _snackBarTheme = SnackBarThemeData(
+  shape: RoundedRectangleBorder(
+    borderRadius: BorderRadius.all(Radius.circular(AppShapes.medium)),
+  ),
+);
 
 class MyApp extends StatefulWidget {
   const MyApp({super.key});
@@ -111,6 +157,16 @@ class _MyAppState extends State<MyApp> {
       pageTransitionsTheme: _pageTransitionsTheme,
       appBarTheme: _appBarTheme,
       navigationBarTheme: _navigationBarTheme,
+      // MD3 Expressive 组件形状覆盖
+      cardTheme: _cardTheme,
+      dialogTheme: _dialogTheme,
+      bottomSheetTheme: _bottomSheetTheme,
+      chipTheme: _chipTheme,
+      filledButtonTheme: _filledButtonTheme,
+      elevatedButtonTheme: _elevatedButtonTheme,
+      outlinedButtonTheme: _outlinedButtonTheme,
+      textButtonTheme: _textButtonTheme,
+      snackBarTheme: _snackBarTheme,
     );
 
     TextTheme textTheme = baseTheme.textTheme;

--- a/lib/pages/about/about_page.dart
+++ b/lib/pages/about/about_page.dart
@@ -4,6 +4,7 @@ import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/providers/app_config_provider.dart';
 import 'package:bugaoshan/providers/app_info_provider.dart';
 import 'package:bugaoshan/services/update_service.dart';
+import 'package:bugaoshan/utils/app_shapes.dart';
 import 'package:bugaoshan/utils/open_link.dart'
     show openDeveloperTeam, openProjectRepository;
 import 'package:bugaoshan/pages/about/release_notes_page.dart';
@@ -211,7 +212,7 @@ class _AboutPageState extends State<AboutPage> {
             width: 100,
             height: 100,
             decoration: BoxDecoration(
-              borderRadius: BorderRadius.circular(24),
+              borderRadius: BorderRadius.circular(AppShapes.largeIncreased),
               boxShadow: [
                 BoxShadow(
                   color: primaryColor.withValues(alpha: 0.2),
@@ -221,7 +222,7 @@ class _AboutPageState extends State<AboutPage> {
               ],
             ),
             child: ClipRRect(
-              borderRadius: BorderRadius.circular(24),
+              borderRadius: BorderRadius.circular(AppShapes.largeIncreased),
               child: Image.asset('assets/icon.png', fit: BoxFit.cover),
             ),
           ),

--- a/lib/pages/about/release_notes_page.dart
+++ b/lib/pages/about/release_notes_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 
 import 'package:bugaoshan/l10n/app_localizations.dart';
+import 'package:bugaoshan/utils/app_shapes.dart';
 
 class ReleaseNotesPage extends StatelessWidget {
   final String version;
@@ -26,7 +27,7 @@ class ReleaseNotesPage extends StatelessWidget {
         styleSheet: MarkdownStyleSheet.fromTheme(Theme.of(context)).copyWith(
           blockquoteDecoration: BoxDecoration(
             color: Theme.of(context).colorScheme.surfaceContainerHighest,
-            borderRadius: BorderRadius.circular(10.0),
+            borderRadius: BorderRadius.circular(AppShapes.small),
           ),
         ),
       ),

--- a/lib/pages/auth/scu_login_page.dart
+++ b/lib/pages/auth/scu_login_page.dart
@@ -8,6 +8,7 @@ import 'package:bugaoshan/providers/scu_auth_provider.dart';
 import 'package:bugaoshan/services/auth/scu_auth.dart' show CaptchaResult;
 import 'package:bugaoshan/services/auth/scu_exceptions.dart';
 import 'package:bugaoshan/services/ocr_service.dart';
+import 'package:bugaoshan/utils/app_shapes.dart';
 
 class ScuLoginPage extends StatefulWidget {
   const ScuLoginPage({super.key});
@@ -183,7 +184,7 @@ class _ScuLoginPageState extends State<ScuLoginPage> {
       Container(
         width: 88,
         decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(12),
+          borderRadius: BorderRadius.circular(AppShapes.medium),
           boxShadow: [
             BoxShadow(
               color: Colors.black.withValues(alpha: 0.08),
@@ -193,7 +194,7 @@ class _ScuLoginPageState extends State<ScuLoginPage> {
           ],
         ),
         child: ClipRRect(
-          borderRadius: BorderRadius.circular(12),
+          borderRadius: BorderRadius.circular(AppShapes.medium),
           child: Image.asset('assets/scu.webp', fit: BoxFit.cover),
         ),
       ),

--- a/lib/pages/campus/academic_calendar/academic_calendar_page.dart
+++ b/lib/pages/campus/academic_calendar/academic_calendar_page.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
+import 'package:bugaoshan/utils/app_shapes.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/widgets/common/error_widgets.dart';
 import 'package:bugaoshan/widgets/common/image_viewer.dart';
@@ -192,7 +193,7 @@ class _AcademicCalendarPageState extends State<AcademicCalendarPage> {
             onTap: () =>
                 showFullScreenImageViewer(context, imageUrl: _imageUrls[index]),
             child: ClipRRect(
-              borderRadius: BorderRadius.circular(12),
+              borderRadius: BorderRadius.circular(AppShapes.medium),
               child: Image.network(
                 _imageUrls[index],
                 fit: BoxFit.fitWidth,

--- a/lib/pages/campus/balance_query/widgets/balance_card.dart
+++ b/lib/pages/campus/balance_query/widgets/balance_card.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:bugaoshan/utils/app_shapes.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/providers/balance_query_provider.dart';
 import 'package:bugaoshan/services/api/balance_query_service.dart';
@@ -121,7 +122,7 @@ class BalanceCardState extends State<BalanceCard> {
                   padding: const EdgeInsets.all(12),
                   decoration: BoxDecoration(
                     color: widget.iconColor.withValues(alpha: 0.15),
-                    borderRadius: BorderRadius.circular(12),
+                    borderRadius: BorderRadius.circular(AppShapes.medium),
                   ),
                   child: Icon(widget.icon, color: widget.iconColor, size: 28),
                 ),

--- a/lib/pages/campus/balance_query/widgets/bind_room_dialog.dart
+++ b/lib/pages/campus/balance_query/widgets/bind_room_dialog.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:bugaoshan/utils/app_shapes.dart';
 import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/providers/balance_query_provider.dart';
@@ -229,7 +230,7 @@ class BindRoomDialogState extends State<BindRoomDialog> {
                   padding: const EdgeInsets.all(12),
                   decoration: BoxDecoration(
                     color: Theme.of(context).colorScheme.errorContainer,
-                    borderRadius: BorderRadius.circular(8),
+                    borderRadius: BorderRadius.circular(AppShapes.small),
                   ),
                   child: Text(
                     _error!,
@@ -505,7 +506,7 @@ class BindRoomDialogState extends State<BindRoomDialog> {
             padding: const EdgeInsets.all(12),
             decoration: BoxDecoration(
               color: Theme.of(context).colorScheme.surfaceContainerHighest,
-              borderRadius: BorderRadius.circular(8),
+              borderRadius: BorderRadius.circular(AppShapes.small),
             ),
             child: Row(
               children: [Text('${auth.userRealname} (${auth.userNumber})')],

--- a/lib/pages/campus/ccyl/activities_tab.dart
+++ b/lib/pages/campus/ccyl/activities_tab.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:bugaoshan/utils/app_shapes.dart';
 import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/providers/ccyl_provider.dart';
@@ -186,7 +187,7 @@ class _ActivityCard extends StatelessWidget {
             ),
           );
         },
-        borderRadius: BorderRadius.circular(12),
+        borderRadius: BorderRadius.circular(AppShapes.medium),
         child: Padding(
           padding: const EdgeInsets.all(16),
           child: Column(

--- a/lib/pages/campus/ccyl/activity_detail_page.dart
+++ b/lib/pages/campus/ccyl/activity_detail_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:bugaoshan/utils/app_shapes.dart';
 import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/providers/ccyl_provider.dart';
@@ -288,7 +289,7 @@ class _ActivityDetailPageState extends State<ActivityDetailPage> {
       onTap: () =>
           showFullScreenImageViewer(context, imageUrl: _activity!.poster),
       child: ClipRRect(
-        borderRadius: BorderRadius.circular(12),
+        borderRadius: BorderRadius.circular(AppShapes.medium),
         child: Image.network(
           _activity!.poster,
           width: double.infinity,

--- a/lib/pages/campus/ccyl/activity_lib_detail_page.dart
+++ b/lib/pages/campus/ccyl/activity_lib_detail_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:bugaoshan/utils/app_shapes.dart';
 import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/providers/ccyl_provider.dart';
@@ -436,7 +437,7 @@ class _ActivityCard extends StatelessWidget {
             ),
           );
         },
-        borderRadius: BorderRadius.circular(12),
+        borderRadius: BorderRadius.circular(AppShapes.medium),
         child: Padding(
           padding: const EdgeInsets.all(16),
           child: Column(

--- a/lib/pages/campus/ccyl/credit_list_page.dart
+++ b/lib/pages/campus/ccyl/credit_list_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:bugaoshan/utils/app_shapes.dart';
 import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/providers/ccyl_provider.dart';
@@ -448,7 +449,7 @@ class _CreditCard extends StatelessWidget {
       color: selected ? theme.colorScheme.primaryContainer : null,
       child: InkWell(
         onTap: selecting ? onToggle : null,
-        borderRadius: BorderRadius.circular(12),
+        borderRadius: BorderRadius.circular(AppShapes.medium),
         child: Padding(
           padding: const EdgeInsets.all(16),
           child: Column(

--- a/lib/pages/campus/ccyl/my_activities_tab.dart
+++ b/lib/pages/campus/ccyl/my_activities_tab.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:bugaoshan/utils/app_shapes.dart';
 import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/providers/ccyl_provider.dart';
@@ -150,7 +151,7 @@ class _MyActivityCard extends StatelessWidget {
             ),
           );
         },
-        borderRadius: BorderRadius.circular(12),
+        borderRadius: BorderRadius.circular(AppShapes.medium),
         child: Padding(
           padding: const EdgeInsets.all(16),
           child: Column(

--- a/lib/pages/campus/ccyl/ordered_activities_tab.dart
+++ b/lib/pages/campus/ccyl/ordered_activities_tab.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:bugaoshan/utils/app_shapes.dart';
 import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/providers/ccyl_provider.dart';
@@ -171,7 +172,7 @@ class _OrderedActivityCard extends StatelessWidget {
             ),
           );
         },
-        borderRadius: BorderRadius.circular(12),
+        borderRadius: BorderRadius.circular(AppShapes.medium),
         child: Padding(
           padding: const EdgeInsets.all(16),
           child: Column(

--- a/lib/pages/campus/classroom/classroom_detail_page.dart
+++ b/lib/pages/campus/classroom/classroom_detail_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:bugaoshan/utils/app_shapes.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/pages/campus/models/classroom_model.dart';
 
@@ -195,7 +196,7 @@ class ClassroomDetailPage extends StatelessWidget {
       padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
       decoration: BoxDecoration(
         color: color.withValues(alpha: 0.15),
-        borderRadius: BorderRadius.circular(8),
+        borderRadius: BorderRadius.circular(AppShapes.small),
       ),
       child: Row(
         mainAxisSize: MainAxisSize.min,
@@ -284,7 +285,7 @@ class ClassroomDetailPage extends StatelessWidget {
               padding: const EdgeInsets.symmetric(vertical: 4),
               decoration: BoxDecoration(
                 color: bgColor,
-                borderRadius: BorderRadius.circular(6),
+                borderRadius: BorderRadius.circular(AppShapes.small),
               ),
               child: Text(
                 periodLabel,

--- a/lib/pages/campus/classroom/classroom_page.dart
+++ b/lib/pages/campus/classroom/classroom_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:bugaoshan/utils/app_shapes.dart';
 import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/pages/campus/classroom/classroom_detail_page.dart';
@@ -451,7 +452,7 @@ class _ClassroomPageState extends State<ClassroomPage> {
             ),
           );
         },
-        borderRadius: BorderRadius.circular(12),
+        borderRadius: BorderRadius.circular(AppShapes.medium),
         child: Padding(
           padding: const EdgeInsets.all(12),
           child: Column(

--- a/lib/pages/campus/exam_plan/exam_plan_page.dart
+++ b/lib/pages/campus/exam_plan/exam_plan_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:bugaoshan/utils/app_shapes.dart';
 import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/pages/campus/exam_plan/models/exam_info.dart';
@@ -292,7 +293,7 @@ class _ExamPlanPageState extends State<ExamPlanPage> {
                           color: colorScheme.surfaceContainerHighest.withValues(
                             alpha: 0.5,
                           ),
-                          borderRadius: BorderRadius.circular(8),
+                          borderRadius: BorderRadius.circular(AppShapes.small),
                         ),
                         child: Row(
                           children: [

--- a/lib/pages/campus/fitness_test/fitness_test_page.dart
+++ b/lib/pages/campus/fitness_test/fitness_test_page.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
+import 'package:bugaoshan/utils/app_shapes.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
@@ -326,7 +327,7 @@ class _FitnessTestPageState extends State<FitnessTestPage>
       margin: const EdgeInsets.only(bottom: 8),
       child: InkWell(
         onTap: () => _showNoticeDetail(notice, l10n),
-        borderRadius: BorderRadius.circular(12),
+        borderRadius: BorderRadius.circular(AppShapes.medium),
         child: Padding(
           padding: const EdgeInsets.all(16),
           child: Column(
@@ -634,7 +635,7 @@ class _FitnessTestPageState extends State<FitnessTestPage>
                     ),
                     decoration: BoxDecoration(
                       color: gradeColor.withValues(alpha: 0.1),
-                      borderRadius: BorderRadius.circular(12),
+                      borderRadius: BorderRadius.circular(AppShapes.medium),
                     ),
                     child: Text(
                       totalGrade,

--- a/lib/pages/campus/grades/scheme_scores_tab.dart
+++ b/lib/pages/campus/grades/scheme_scores_tab.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:bugaoshan/utils/app_shapes.dart';
 import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/models/scheme_score.dart';
@@ -360,7 +361,7 @@ class ScoreCardWidget extends StatelessWidget {
     if (onTap != null) {
       card = InkWell(
         onTap: onTap,
-        borderRadius: BorderRadius.circular(12),
+        borderRadius: BorderRadius.circular(AppShapes.medium),
         child: card,
       );
     }

--- a/lib/pages/campus/train_program/train_program_page.dart
+++ b/lib/pages/campus/train_program/train_program_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:bugaoshan/utils/app_shapes.dart';
 import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/pages/campus/train_program/models/train_program.dart';
@@ -231,7 +232,7 @@ class _TrainProgramPageState extends State<TrainProgramPage> {
                         padding: const EdgeInsets.all(8),
                         decoration: BoxDecoration(
                           color: Theme.of(context).colorScheme.primaryContainer,
-                          borderRadius: BorderRadius.circular(8),
+                          borderRadius: BorderRadius.circular(AppShapes.small),
                         ),
                         child: Icon(
                           Icons.school_outlined,

--- a/lib/pages/campus_page.dart
+++ b/lib/pages/campus_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/models/campus_item_config.dart';
+import 'package:bugaoshan/utils/app_shapes.dart';
 import 'package:bugaoshan/utils/constants.dart';
 import 'package:bugaoshan/widgets/route/router_utils.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -151,7 +152,7 @@ class _CampusCard extends StatelessWidget {
     return Card(
       child: InkWell(
         onTap: onTap,
-        borderRadius: BorderRadius.circular(12),
+        borderRadius: BorderRadius.circular(AppShapes.large),
         child: Padding(
           padding: const EdgeInsets.all(16),
           child: Row(
@@ -160,7 +161,7 @@ class _CampusCard extends StatelessWidget {
                 padding: const EdgeInsets.all(12),
                 decoration: BoxDecoration(
                   color: Theme.of(context).colorScheme.primaryContainer,
-                  borderRadius: BorderRadius.circular(12),
+                  borderRadius: BorderRadius.circular(AppShapes.medium),
                 ),
                 child: Icon(
                   icon,
@@ -234,7 +235,7 @@ class _MoreFeaturesCard extends StatelessWidget {
           Uri.parse('$appLink/issues/new?template=feature_request.yml'),
           mode: LaunchMode.externalApplication,
         ),
-        borderRadius: BorderRadius.circular(12),
+        borderRadius: BorderRadius.circular(AppShapes.large),
         child: Padding(
           padding: const EdgeInsets.all(16),
           child: Row(
@@ -243,7 +244,7 @@ class _MoreFeaturesCard extends StatelessWidget {
                 padding: const EdgeInsets.all(12),
                 decoration: BoxDecoration(
                   color: Theme.of(context).colorScheme.secondaryContainer,
-                  borderRadius: BorderRadius.circular(12),
+                  borderRadius: BorderRadius.circular(AppShapes.medium),
                 ),
                 child: Icon(
                   Icons.add_comment_outlined,

--- a/lib/pages/course/course_page.dart
+++ b/lib/pages/course/course_page.dart
@@ -17,6 +17,7 @@ import 'package:bugaoshan/widgets/route/router_utils.dart';
 import 'package:bugaoshan/utils/export_schedule_utils.dart';
 import 'package:bugaoshan/utils/holiday_utils.dart';
 import 'package:bugaoshan/widgets/course/special_day_sheet.dart';
+import 'package:bugaoshan/utils/app_shapes.dart';
 
 part 'course_page_swipe_page_view.dart';
 part 'course_page_top_bar.dart';

--- a/lib/pages/course/course_page_actions.dart
+++ b/lib/pages/course/course_page_actions.dart
@@ -7,7 +7,9 @@ extension _CoursePageActions on _CoursePageState {
     showModalBottomSheet(
       context: context,
       shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+        borderRadius: BorderRadius.vertical(
+          top: Radius.circular(AppShapes.extraLarge),
+        ),
       ),
       builder: (context) => SafeArea(
         child: Padding(
@@ -95,7 +97,9 @@ extension _CoursePageActions on _CoursePageState {
       context: context,
       isScrollControlled: true,
       shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+        borderRadius: BorderRadius.vertical(
+          top: Radius.circular(AppShapes.extraLarge),
+        ),
       ),
       builder: (context) =>
           CourseDetailSheet(course: course, courseProvider: courseProvider),

--- a/lib/pages/course/course_schedule_setting.dart
+++ b/lib/pages/course/course_schedule_setting.dart
@@ -9,6 +9,7 @@ import 'package:bugaoshan/providers/scu_auth_provider.dart';
 import 'package:bugaoshan/services/api/zhjw_api_service.dart';
 import 'package:bugaoshan/services/auth/scu_exceptions.dart';
 import 'package:bugaoshan/widgets/common/styled_card.dart';
+import 'package:bugaoshan/utils/app_shapes.dart';
 
 class CourseScheduleSetting extends StatefulWidget {
   const CourseScheduleSetting({super.key});
@@ -303,7 +304,9 @@ class _CourseScheduleSettingState extends State<CourseScheduleSetting> {
       context: context,
       backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+        borderRadius: BorderRadius.vertical(
+          top: Radius.circular(AppShapes.largeIncreased),
+        ),
       ),
       builder: (BuildContext context) {
         return SizedBox(

--- a/lib/pages/course/schedule_management_page.dart
+++ b/lib/pages/course/schedule_management_page.dart
@@ -8,6 +8,7 @@ import 'package:bugaoshan/providers/course_provider.dart';
 import 'package:bugaoshan/widgets/dialog/dialog.dart';
 import 'package:bugaoshan/widgets/route/router_utils.dart';
 import 'package:bugaoshan/utils/export_schedule_utils.dart';
+import 'package:bugaoshan/utils/app_shapes.dart';
 
 /// 弹窗让用户输入新课表名称，校验重名后通过 [courseProvider.addSchedule] 添加。
 /// 复用当前选中的课表配置（timeSlots 等）作为模板。
@@ -70,7 +71,9 @@ class ScheduleManagementPage extends StatelessWidget {
     showModalBottomSheet(
       context: context,
       shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+        borderRadius: BorderRadius.vertical(
+          top: Radius.circular(AppShapes.extraLarge),
+        ),
       ),
       builder: (context) => SafeArea(
         child: Padding(

--- a/lib/pages/course/time_slot_setting_page.dart
+++ b/lib/pages/course/time_slot_setting_page.dart
@@ -3,6 +3,7 @@ import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/models/course.dart';
 import 'package:bugaoshan/providers/course_provider.dart';
+import 'package:bugaoshan/utils/app_shapes.dart';
 
 class TimeSlotSettingPage extends StatefulWidget {
   final int morningSections;
@@ -490,7 +491,7 @@ class _TimeSlotEditor extends StatelessWidget {
                       border: Border.all(
                         color: Theme.of(context).colorScheme.outline,
                       ),
-                      borderRadius: BorderRadius.circular(8),
+                      borderRadius: BorderRadius.circular(AppShapes.small),
                     ),
                     child: Text(startStr),
                   ),
@@ -510,7 +511,7 @@ class _TimeSlotEditor extends StatelessWidget {
                       border: Border.all(
                         color: Theme.of(context).colorScheme.outline,
                       ),
-                      borderRadius: BorderRadius.circular(8),
+                      borderRadius: BorderRadius.circular(AppShapes.small),
                     ),
                     child: Text(endStr),
                   ),

--- a/lib/pages/profile/login_status_card.dart
+++ b/lib/pages/profile/login_status_card.dart
@@ -4,6 +4,7 @@ import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/pages/auth/scu_login_page.dart';
 import 'package:bugaoshan/providers/scu_auth_provider.dart';
+import 'package:bugaoshan/utils/app_shapes.dart';
 import 'package:bugaoshan/widgets/route/router_utils.dart';
 
 enum LoginStatus {
@@ -123,7 +124,7 @@ class _LoginStatusCardState extends State<LoginStatusCard> {
     return Container(
       decoration: BoxDecoration(
         color: theme.colorScheme.surface,
-        borderRadius: BorderRadius.circular(16),
+        borderRadius: BorderRadius.circular(AppShapes.largeIncreased),
         border: Border.all(color: theme.dividerColor.withValues(alpha: 0.08)),
       ),
       child: Column(
@@ -200,7 +201,7 @@ class _LoginStatusCardState extends State<LoginStatusCard> {
             : status.isSessionExpired
             ? theme.colorScheme.tertiaryContainer
             : theme.colorScheme.surfaceContainerHighest,
-        borderRadius: BorderRadius.circular(14),
+        borderRadius: BorderRadius.circular(AppShapes.medium),
       ),
       child: status.isAutoLoggingIn
           ? SizedBox(
@@ -239,7 +240,9 @@ class _LoginStatusCardState extends State<LoginStatusCard> {
           : status.isLoggedIn
           ? _onLogout
           : _onLogin,
-      borderRadius: const BorderRadius.vertical(bottom: Radius.circular(16)),
+      borderRadius: const BorderRadius.vertical(
+        bottom: Radius.circular(AppShapes.largeIncreased),
+      ),
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 14),
         child: Row(

--- a/lib/pages/profile/user_info_card.dart
+++ b/lib/pages/profile/user_info_card.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/providers/user_info_provider.dart';
+import 'package:bugaoshan/utils/app_shapes.dart';
 
 class UserInfoCard extends StatefulWidget {
   const UserInfoCard({super.key});
@@ -61,7 +62,7 @@ class _UserInfoCardState extends State<UserInfoCard> {
     final card = Container(
       decoration: BoxDecoration(
         color: theme.colorScheme.surface,
-        borderRadius: BorderRadius.circular(16),
+        borderRadius: BorderRadius.circular(AppShapes.largeIncreased),
         border: Border.all(color: theme.dividerColor.withValues(alpha: 0.08)),
       ),
       padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
@@ -71,7 +72,7 @@ class _UserInfoCardState extends State<UserInfoCard> {
     if (onTap != null) {
       return InkWell(
         onTap: onTap,
-        borderRadius: BorderRadius.circular(16),
+        borderRadius: BorderRadius.circular(AppShapes.largeIncreased),
         child: card,
       );
     }

--- a/lib/pages/settings/add_widget/add_widget_page.dart
+++ b/lib/pages/settings/add_widget/add_widget_page.dart
@@ -6,6 +6,7 @@ import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/providers/app_config_provider.dart';
 import 'package:bugaoshan/services/widget_update_service.dart';
 import 'package:bugaoshan/models/widget_size.dart';
+import 'package:bugaoshan/utils/app_shapes.dart';
 
 import 'battery_optimization_card.dart';
 import 'hint_card.dart';
@@ -186,7 +187,7 @@ class _WidgetPickerCardState extends State<_WidgetPickerCard> {
                   height: 56,
                   decoration: BoxDecoration(
                     color: Theme.of(context).colorScheme.primaryContainer,
-                    borderRadius: BorderRadius.circular(12),
+                    borderRadius: BorderRadius.circular(AppShapes.medium),
                   ),
                   child: Icon(
                     Icons.widgets_outlined,

--- a/lib/pages/settings/add_widget/widget_size_card.dart
+++ b/lib/pages/settings/add_widget/widget_size_card.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:bugaoshan/utils/app_shapes.dart';
 
 class WidgetSizeCard extends StatelessWidget {
   final IconData icon;
@@ -33,7 +34,7 @@ class WidgetSizeCard extends StatelessWidget {
               height: 56,
               decoration: BoxDecoration(
                 color: colorScheme.primaryContainer,
-                borderRadius: BorderRadius.circular(12),
+                borderRadius: BorderRadius.circular(AppShapes.medium),
               ),
               child: Icon(
                 icon,

--- a/lib/pages/settings/set_course_style_page.dart
+++ b/lib/pages/settings/set_course_style_page.dart
@@ -7,6 +7,7 @@ import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/pages/course/course_page.dart';
 import 'package:bugaoshan/providers/app_config_provider.dart';
 import 'package:bugaoshan/widgets/common/styled_widget.dart';
+import 'package:bugaoshan/utils/app_shapes.dart';
 import 'package:bugaoshan/providers/set_theme_color_provider.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:path/path.dart' as p;
@@ -48,7 +49,7 @@ class SetCourseStylePage extends StatelessWidget {
                     child: Padding(
                       padding: const EdgeInsets.fromLTRB(8, 0, 8, 0),
                       child: ClipRRect(
-                        borderRadius: BorderRadius.circular(12),
+                        borderRadius: BorderRadius.circular(AppShapes.medium),
                         child: const CoursePage(demoMode: true),
                       ),
                     ),

--- a/lib/pages/settings/set_dock_page.dart
+++ b/lib/pages/settings/set_dock_page.dart
@@ -5,6 +5,7 @@ import 'package:bugaoshan/models/campus_item_config.dart';
 import 'package:bugaoshan/providers/app_config_provider.dart';
 import 'package:bugaoshan/utils/constants.dart';
 import 'package:bugaoshan/widgets/dialog/dialog.dart';
+import 'package:bugaoshan/utils/app_shapes.dart';
 
 class SetDockPage extends StatefulWidget {
   const SetDockPage({super.key});
@@ -86,7 +87,7 @@ class _SetDockPageState extends State<SetDockPage> {
             height: 64,
             decoration: BoxDecoration(
               color: theme.colorScheme.surfaceContainerHighest,
-              borderRadius: BorderRadius.circular(16),
+              borderRadius: BorderRadius.circular(AppShapes.largeIncreased),
             ),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceEvenly,
@@ -123,7 +124,7 @@ class _SetDockPageState extends State<SetDockPage> {
             final t = Curves.easeInOut.transform(animation.value);
             return Container(
               decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(12),
+                borderRadius: BorderRadius.circular(AppShapes.medium),
                 color: theme.colorScheme.surface,
                 boxShadow: t > 0
                     ? [

--- a/lib/pages/settings/set_duration_page.dart
+++ b/lib/pages/settings/set_duration_page.dart
@@ -1,7 +1,8 @@
-﻿import 'package:flutter/material.dart';
+import 'package:flutter/material.dart';
 import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/providers/app_config_provider.dart';
+import 'package:bugaoshan/utils/app_shapes.dart';
 
 class SetDurationPage extends StatefulWidget {
   const SetDurationPage({super.key});
@@ -126,7 +127,7 @@ class _SetDurationPageState extends State<SetDurationPage> {
               child: Container(
                 decoration: BoxDecoration(
                   color: Theme.of(context).colorScheme.surfaceContainerHighest,
-                  borderRadius: BorderRadius.circular(12),
+                  borderRadius: BorderRadius.circular(AppShapes.medium),
                 ),
                 child: Center(
                   child: AnimatedContainer(

--- a/lib/pages/wizard/login_page.dart
+++ b/lib/pages/wizard/login_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:bugaoshan/utils/app_shapes.dart';
 import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/pages/course/import_schedule_page.dart';
@@ -35,7 +36,7 @@ class _LoginPageState extends State<LoginPage> {
             height: 72,
             decoration: BoxDecoration(
               color: colorScheme.primaryContainer,
-              borderRadius: BorderRadius.circular(18),
+              borderRadius: BorderRadius.circular(AppShapes.largeIncreased),
             ),
             child: Icon(
               Icons.login_rounded,
@@ -142,7 +143,7 @@ class _StepCard extends StatelessWidget {
     return Container(
       decoration: BoxDecoration(
         color: colorScheme.surfaceContainerLow,
-        borderRadius: BorderRadius.circular(16),
+        borderRadius: BorderRadius.circular(AppShapes.largeIncreased),
         border: Border.all(
           color: colorScheme.outlineVariant.withValues(alpha: 0.5),
         ),
@@ -156,7 +157,7 @@ class _StepCard extends StatelessWidget {
               height: 40,
               decoration: BoxDecoration(
                 color: colorScheme.primaryContainer,
-                borderRadius: BorderRadius.circular(12),
+                borderRadius: BorderRadius.circular(AppShapes.medium),
               ),
               child: Center(
                 child: Text(

--- a/lib/pages/wizard/welcome_page.dart
+++ b/lib/pages/wizard/welcome_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:bugaoshan/utils/app_shapes.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 
 class WelcomePage extends StatelessWidget {
@@ -20,7 +21,7 @@ class WelcomePage extends StatelessWidget {
             width: 96,
             height: 96,
             decoration: BoxDecoration(
-              borderRadius: BorderRadius.circular(22),
+              borderRadius: BorderRadius.circular(AppShapes.largeIncreased),
               boxShadow: [
                 BoxShadow(
                   color: colorScheme.primary.withValues(alpha: 0.2),
@@ -30,7 +31,7 @@ class WelcomePage extends StatelessWidget {
               ],
             ),
             child: ClipRRect(
-              borderRadius: BorderRadius.circular(22),
+              borderRadius: BorderRadius.circular(AppShapes.largeIncreased),
               child: Image.asset('assets/icon.png', fit: BoxFit.cover),
             ),
           ),

--- a/lib/pages/wizard/wizard_card.dart
+++ b/lib/pages/wizard/wizard_card.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:bugaoshan/utils/app_shapes.dart';
 
 class WizardCard extends StatelessWidget {
   final IconData icon;
@@ -27,7 +28,7 @@ class WizardCard extends StatelessWidget {
       child: Container(
         decoration: BoxDecoration(
           color: colorScheme.surfaceContainerLow,
-          borderRadius: BorderRadius.circular(16),
+          borderRadius: BorderRadius.circular(AppShapes.largeIncreased),
           border: Border.all(
             color: colorScheme.outlineVariant.withValues(alpha: 0.5),
           ),
@@ -42,7 +43,7 @@ class WizardCard extends StatelessWidget {
                 height: 52,
                 decoration: BoxDecoration(
                   color: iconBackground,
-                  borderRadius: BorderRadius.circular(14),
+                  borderRadius: BorderRadius.circular(AppShapes.medium),
                 ),
                 child: Icon(icon, size: 28, color: iconColor),
               ),

--- a/lib/utils/app_shapes.dart
+++ b/lib/utils/app_shapes.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+/// MD3 Expressive 形状令牌
+/// 对齐 Material 3 Expressive Corner Radius Scale
+class AppShapes {
+  AppShapes._();
+
+  /// 8dp - 小标签、chip、状态标记
+  static const double small = 8;
+
+  /// 12dp - 图标容器、中等元素
+  static const double medium = 12;
+
+  /// 16dp - 次级卡片、输入框
+  static const double large = 16;
+
+  /// 20dp - 主卡片容器（MD3 Expressive: Large increased）
+  static const double largeIncreased = 20;
+
+  /// 28dp - 底部弹窗、超大容器（MD3 Expressive: Extra Large）
+  static const double extraLarge = 28;
+
+  /// 完全圆角 - 药丸形/圆形
+  static const double full = 999;
+}
+
+/// 集中化动效曲线（为后续 MD3 Expressive 动效适配预留）
+class AppCurves {
+  AppCurves._();
+
+  /// 标准缓动
+  static const Curve standard = Curves.easeInOutCubic;
+
+  /// 强调缓动
+  static const Curve emphasized = Curves.easeInOutCubic;
+}

--- a/lib/utils/export_schedule_utils.dart
+++ b/lib/utils/export_schedule_utils.dart
@@ -6,6 +6,7 @@ import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/models/course.dart';
 import 'package:bugaoshan/providers/course_provider.dart';
 import 'package:bugaoshan/providers/export_schedule_provider.dart';
+import 'package:bugaoshan/utils/app_shapes.dart';
 import 'package:flutter/services.dart';
 
 Future<void> showExportScheduleSheet(
@@ -29,7 +30,9 @@ Future<void> showExportScheduleSheet(
   final ExportAction? action = await showModalBottomSheet(
     context: context,
     shape: const RoundedRectangleBorder(
-      borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      borderRadius: BorderRadius.vertical(
+        top: Radius.circular(AppShapes.extraLarge),
+      ),
     ),
     builder: (sheetContext) => SafeArea(
       child: Padding(

--- a/lib/widgets/common/info_card.dart
+++ b/lib/widgets/common/info_card.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:bugaoshan/utils/app_shapes.dart';
 
 /// A card container that groups child widgets with dividers between them.
 ///
@@ -16,13 +17,13 @@ class InfoCard extends StatelessWidget {
 
     return Container(
       decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(16),
+        borderRadius: BorderRadius.circular(AppShapes.largeIncreased),
         border: Border.all(color: theme.dividerColor.withValues(alpha: 0.08)),
       ),
       clipBehavior: Clip.antiAlias,
       child: Material(
         color: surfaceColor,
-        borderRadius: BorderRadius.circular(16),
+        borderRadius: BorderRadius.circular(AppShapes.largeIncreased),
         clipBehavior: Clip.antiAlias,
         child: Column(
           mainAxisSize: MainAxisSize.min,

--- a/lib/widgets/common/styled_card.dart
+++ b/lib/widgets/common/styled_card.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:bugaoshan/utils/app_shapes.dart';
 
 class StyledCard extends StatelessWidget {
   final Widget child;
@@ -31,7 +32,9 @@ class StyledCard extends StatelessWidget {
       margin: margin ?? const EdgeInsets.only(bottom: 16),
       elevation: elevation ?? 0,
       shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(borderRadius ?? 16),
+        borderRadius: BorderRadius.circular(
+          borderRadius ?? AppShapes.largeIncreased,
+        ),
         side:
             borderSide ??
             BorderSide(
@@ -41,7 +44,9 @@ class StyledCard extends StatelessWidget {
       ),
       color: backgroundColor ?? colorScheme.surface,
       child: InkWell(
-        borderRadius: BorderRadius.circular(borderRadius ?? 16),
+        borderRadius: BorderRadius.circular(
+          borderRadius ?? AppShapes.largeIncreased,
+        ),
         onTap: onTap,
         child: Padding(
           padding: padding ?? const EdgeInsets.all(16),

--- a/lib/widgets/common/styled_tile.dart
+++ b/lib/widgets/common/styled_tile.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:bugaoshan/utils/app_shapes.dart';
 
 /// Base tile with padding and optional InkWell tap.
 class BaseTile extends StatelessWidget {
@@ -16,7 +17,7 @@ class BaseTile extends StatelessWidget {
     if (onTap != null) {
       return InkWell(
         onTap: onTap,
-        borderRadius: BorderRadius.circular(16),
+        borderRadius: BorderRadius.circular(AppShapes.largeIncreased),
         child: tile,
       );
     }
@@ -39,7 +40,7 @@ class TileIcon extends StatelessWidget {
       height: 36,
       decoration: BoxDecoration(
         color: primaryColor.withValues(alpha: 0.1),
-        borderRadius: BorderRadius.circular(10),
+        borderRadius: BorderRadius.circular(AppShapes.medium),
       ),
       child: Icon(icon, color: primaryColor, size: 20),
     );

--- a/lib/widgets/course/course_detail_sheet.dart
+++ b/lib/widgets/course/course_detail_sheet.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
+import 'package:bugaoshan/utils/app_shapes.dart';
 import 'package:bugaoshan/models/course.dart';
 import 'package:bugaoshan/pages/course/course_edit_page.dart';
 import 'package:bugaoshan/providers/course_provider.dart';
@@ -39,7 +40,9 @@ class CourseDetailSheet extends StatelessWidget {
     return Container(
       decoration: BoxDecoration(
         color: Theme.of(context).colorScheme.surface,
-        borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
+        borderRadius: const BorderRadius.vertical(
+          top: Radius.circular(AppShapes.extraLarge),
+        ),
       ),
       child: SafeArea(
         child: Column(

--- a/lib/widgets/course/special_day_sheet.dart
+++ b/lib/widgets/course/special_day_sheet.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/utils/holiday_utils.dart';
+import 'package:bugaoshan/utils/app_shapes.dart';
 
 /// 点击课表表头的特殊日（假/节/气）后弹出的信息悬浮窗
 Future<void> showSpecialDaySheet(
@@ -37,7 +38,9 @@ Future<void> _showSheet(
   await showModalBottomSheet(
     context: context,
     shape: const RoundedRectangleBorder(
-      borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      borderRadius: BorderRadius.vertical(
+        top: Radius.circular(AppShapes.extraLarge),
+      ),
     ),
     builder: (ctx) => SafeArea(
       child: Padding(

--- a/lib/widgets/eula_content.dart
+++ b/lib/widgets/eula_content.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
+import 'package:bugaoshan/utils/app_shapes.dart';
 
 /// EULA 版本号，需要与 eula.md 中的 version 保持一致
 const int currentEulaVersion = 1;
@@ -86,10 +87,10 @@ class _EulaContentState extends State<EulaContent>
                     border: Border.all(
                       color: colorScheme.colorScheme.outlineVariant,
                     ),
-                    borderRadius: BorderRadius.circular(6),
+                    borderRadius: BorderRadius.circular(AppShapes.small),
                   ),
                   child: ClipRRect(
-                    borderRadius: BorderRadius.circular(6),
+                    borderRadius: BorderRadius.circular(AppShapes.small),
                     child: Markdown(
                       data: _eulaContent,
                       selectable: true,
@@ -112,7 +113,9 @@ class _EulaContentState extends State<EulaContent>
                               color: colorScheme
                                   .colorScheme
                                   .surfaceContainerHighest,
-                              borderRadius: BorderRadius.circular(8),
+                              borderRadius: BorderRadius.circular(
+                                AppShapes.small,
+                              ),
                             ),
                           ),
                     ),


### PR DESCRIPTION
## 变更内容

- 新增 \lib/utils/app_shapes.dart\ 集中化形状令牌
- 更新 42 个文件，统一 borderRadius 为语义化令牌
- 主卡片容器 16→20 (largeIncreased)
- 底部弹窗 20→28 (extraLarge)
- 中等容器 12→medium，小标签 8→small
- app.dart 主题新增 Card/Dialog/BottomSheet/Button 形状覆盖
- 课程块配色保持不变

## 验证

- flutter analyze 通过，0 issues
- 纯视觉常量替换，不影响业务逻辑