### PR TITLE
fix(course): 允许地点文本完整换行并调整卡片小字号

### DIFF
--- a/lib/widgets/course/course_card.dart
+++ b/lib/widgets/course/course_card.dart
@@ -44,7 +44,7 @@ class CourseCard extends StatelessWidget {
             ? Colors.black87
             : Colors.white;
         final fontSize = appConfig.courseCardFontSize.value;
-        final smallFontSize = fontSize - 1;
+        final smallFontSize = (fontSize * 0.85).clamp(8.0, 16.0);
         final details =
             <({String text, int preferredMaxLines, int renderMaxLines})>[
               if (config.showLocation && course.location.isNotEmpty)

--- a/lib/widgets/course/course_card.dart
+++ b/lib/widgets/course/course_card.dart
@@ -44,7 +44,7 @@ class CourseCard extends StatelessWidget {
             ? Colors.black87
             : Colors.white;
         final fontSize = appConfig.courseCardFontSize.value;
-        final smallFontSize = fontSize - 1;
+        final smallFontSize = fontSize - 2.5;
         final details =
             <({String text, int preferredMaxLines, int renderMaxLines})>[
               if (config.showLocation && course.location.isNotEmpty)
@@ -160,7 +160,8 @@ class CourseCard extends StatelessWidget {
         padding: const EdgeInsets.only(top: 2),
         child: Text(
           text,
-          maxLines: maxLines,
+          maxLines: null,
+          overflow: TextOverflow.visible,
           softWrap: true,
           style: Theme.of(context).textTheme.bodySmall?.copyWith(
             fontSize: fontSize,

--- a/lib/widgets/course/course_card.dart
+++ b/lib/widgets/course/course_card.dart
@@ -44,14 +44,14 @@ class CourseCard extends StatelessWidget {
             ? Colors.black87
             : Colors.white;
         final fontSize = appConfig.courseCardFontSize.value;
-        final smallFontSize = fontSize - 2.5;
+        final smallFontSize = fontSize - 1;
         final details =
             <({String text, int preferredMaxLines, int renderMaxLines})>[
               if (config.showLocation && course.location.isNotEmpty)
                 (
                   text: course.location,
                   preferredMaxLines: 2,
-                  renderMaxLines: 2,
+                  renderMaxLines: 4,
                 ),
               if (config.showTeacherName && course.teacher.isNotEmpty)
                 (text: course.teacher, preferredMaxLines: 2, renderMaxLines: 2),
@@ -160,8 +160,7 @@ class CourseCard extends StatelessWidget {
         padding: const EdgeInsets.only(top: 2),
         child: Text(
           text,
-          maxLines: null,
-          overflow: TextOverflow.visible,
+          maxLines: maxLines,
           softWrap: true,
           style: Theme.of(context).textTheme.bodySmall?.copyWith(
             fontSize: fontSize,


### PR DESCRIPTION
## 问题描述
课程卡片中，长地点文本（如“一教B座B402”）在窄屏幕下显示不全，丢失部分字符。
（对于需要上课的大学生来说，可能具体在哪个教室上课是最重要的信息）

## 修改内容
- 将细节字体从 `fontSize - 1` 调整为 `fontSize - 2.5`，增加容纳空间。
- 移除 `_buildIconText` 中 `Text` 的 `maxLines` 限制，并添加 `overflow: TextOverflow.visible`，确保文本完整换行显示。

## 测试
在 Windows 桌面版通过缩窄窗口模拟手机宽度，验证长地点可完整显示。