### PR TITLE
feat: classroom list add current-free filter 增加当前时段空闲教室的筛选和展示

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -474,6 +474,7 @@
     "ccylSeriesName": "Series Name",
     "ccylOrganizer": "Organizer",
     "noData": "No Data",
+    "noFreeClassrooms": "No free classrooms right now",
     "networkDeviceQuery": "Network Device Query",
     "networkDeviceQueryDesc": "Query campus network account and online devices",
     "networkDeviceUserInfo": "User Information",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2635,6 +2635,12 @@ abstract class AppLocalizations {
   /// **'No Data'**
   String get noData;
 
+  /// No description provided for @noFreeClassrooms.
+  ///
+  /// In en, this message translates to:
+  /// **'No free classrooms right now'**
+  String get noFreeClassrooms;
+
   /// No description provided for @networkDeviceQuery.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1354,6 +1354,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get noData => 'No Data';
 
   @override
+  String get noFreeClassrooms => 'No free classrooms right now';
+
+  @override
   String get networkDeviceQuery => 'Network Device Query';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1316,6 +1316,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get noData => '暂无数据';
 
   @override
+  String get noFreeClassrooms => '当前没有空闲教室';
+
+  @override
   String get networkDeviceQuery => '校园网设备查询';
 
   @override

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -470,6 +470,7 @@
     "ccylSeriesName": "系列名称",
     "ccylOrganizer": "主办单位",
     "noData": "暂无数据",
+    "noFreeClassrooms": "当前没有空闲教室",
     "networkDeviceQuery": "校园网设备查询",
     "networkDeviceQueryDesc": "查询校园网账户和在线设备",
     "networkDeviceUserInfo": "用户信息",

--- a/lib/pages/campus/classroom/classroom_page.dart
+++ b/lib/pages/campus/classroom/classroom_page.dart
@@ -1,9 +1,12 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:bugaoshan/utils/app_shapes.dart';
 import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/pages/campus/classroom/classroom_detail_page.dart';
 import 'package:bugaoshan/pages/campus/models/classroom_model.dart';
+import 'package:bugaoshan/providers/course_provider.dart';
 import 'package:bugaoshan/providers/scu_auth_provider.dart';
 import 'package:bugaoshan/services/api/zhjw_api_service.dart';
 import 'package:bugaoshan/services/auth/scu_exceptions.dart';
@@ -23,6 +26,7 @@ class ClassroomPage extends StatefulWidget {
 
 class _ClassroomPageState extends State<ClassroomPage> {
   late final ZhjwApiService _zhjwApi;
+  Timer? _clockTimer;
 
   List<ClassroomCampus> _campuses = [];
   List<ClassroomBuilding> _allBuildings = [];
@@ -35,18 +39,23 @@ class _ClassroomPageState extends State<ClassroomPage> {
   bool _isInitialLoad = true;
   String? _error;
   DateTime _selectedDate = DateTime.now();
+  bool _showCurrentFreeOnly = false;
 
   @override
   void initState() {
     super.initState();
     _zhjwApi = getIt<ZhjwApiService>();
     getIt<ScuAuthProvider>().addListener(_onAuthChanged);
+    _clockTimer = Timer.periodic(const Duration(minutes: 1), (_) {
+      if (mounted) setState(() {});
+    });
     _loadIndex();
   }
 
   @override
   void dispose() {
     getIt<ScuAuthProvider>().removeListener(_onAuthChanged);
+    _clockTimer?.cancel();
     super.dispose();
   }
 
@@ -191,6 +200,58 @@ class _ClassroomPageState extends State<ClassroomPage> {
     if (_selectedBuilding != null) {
       _queryBuilding(_selectedBuilding!);
     }
+  }
+
+  int? _currentPeriod() {
+    final timeSlots = getIt<CourseProvider>().scheduleConfig.value.timeSlots;
+    if (timeSlots.isEmpty) return null;
+
+    final now = DateTime.now();
+    final currentMinutes = now.hour * 60 + now.minute;
+
+    const preClassLeadMinutes = 15;
+
+    for (var index = 0; index < timeSlots.length; index++) {
+      final slot = timeSlots[index];
+      final startMinutes = slot.startTime.hour * 60 + slot.startTime.minute;
+      final endMinutes = slot.endTime.hour * 60 + slot.endTime.minute;
+      if (currentMinutes >= startMinutes && currentMinutes < endMinutes) {
+        return index + 1;
+      }
+
+      if (index == 0 &&
+          currentMinutes >= startMinutes - preClassLeadMinutes &&
+          currentMinutes < startMinutes) {
+        return 1;
+      }
+
+      if (index + 1 < timeSlots.length) {
+        final nextSlot = timeSlots[index + 1];
+        final nextStartMinutes =
+            nextSlot.startTime.hour * 60 + nextSlot.startTime.minute;
+        if (currentMinutes >= endMinutes && currentMinutes < nextStartMinutes) {
+          return index + 2;
+        }
+      }
+    }
+    return null;
+  }
+
+  List<ClassroomInfo> _visibleRooms() {
+    final result = _queryResult;
+    if (result == null) return [];
+
+    final currentPeriod = _currentPeriod();
+    if (!_showCurrentFreeOnly || !_isToday || currentPeriod == null) {
+      return result.classrooms;
+    }
+
+    return result.classrooms.where((room) {
+      final status = result.periodStatusMap(
+        room.classroomNumber,
+      )[currentPeriod];
+      return status == null || status == ClassroomPeriodStatus.free;
+    }).toList();
   }
 
   void _goBack() {
@@ -357,7 +418,9 @@ class _ClassroomPageState extends State<ClassroomPage> {
 
     if (_queryResult == null) return const SizedBox.shrink();
 
-    final rooms = _queryResult!.classrooms;
+    final currentPeriod = _currentPeriod();
+    final canFilterCurrentFree = _isToday && currentPeriod != null;
+    final rooms = _visibleRooms();
 
     return Column(
       children: [
@@ -394,7 +457,9 @@ class _ClassroomPageState extends State<ClassroomPage> {
         ),
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16),
-          child: Row(
+          child: Wrap(
+            spacing: 8,
+            runSpacing: 8,
             children: [
               ActionChip(
                 avatar: const Icon(Icons.calendar_today, size: 18),
@@ -402,9 +467,21 @@ class _ClassroomPageState extends State<ClassroomPage> {
                 onPressed: _pickDate,
               ),
               if (!_isToday) ...[
-                const SizedBox(width: 8),
                 ActionChip(label: Text(l10n.today), onPressed: _goToToday),
               ],
+              FilterChip(
+                avatar: const Icon(Icons.filter_alt_outlined, size: 18),
+                label: Text('${l10n.current}${l10n.free}'),
+                selected: _showCurrentFreeOnly && canFilterCurrentFree,
+                onSelected: canFilterCurrentFree
+                    ? (selected) {
+                        setState(() {
+                          _showCurrentFreeOnly = selected;
+                        });
+                      }
+                    : null,
+                showCheckmark: false,
+              ),
             ],
           ),
         ),
@@ -412,7 +489,9 @@ class _ClassroomPageState extends State<ClassroomPage> {
           child: rooms.isEmpty
               ? Center(
                   child: Text(
-                    l10n.noData,
+                    _showCurrentFreeOnly && canFilterCurrentFree
+                        ? '当前没有空闲教室'
+                        : l10n.noData,
                     style: Theme.of(context).textTheme.bodyLarge?.copyWith(
                       color: Theme.of(context).colorScheme.onSurfaceVariant,
                     ),

--- a/lib/pages/campus/classroom/classroom_page.dart
+++ b/lib/pages/campus/classroom/classroom_page.dart
@@ -242,8 +242,12 @@ class _ClassroomPageState extends State<ClassroomPage> {
     if (result == null) return [];
 
     final currentPeriod = _currentPeriod();
-    if (!_showCurrentFreeOnly || !_isToday || currentPeriod == null) {
+    if (!_showCurrentFreeOnly || !_isToday) {
       return result.classrooms;
+    }
+
+    if (currentPeriod == null) {
+      return [];
     }
 
     return result.classrooms.where((room) {
@@ -419,7 +423,8 @@ class _ClassroomPageState extends State<ClassroomPage> {
     if (_queryResult == null) return const SizedBox.shrink();
 
     final currentPeriod = _currentPeriod();
-    final canFilterCurrentFree = _isToday && currentPeriod != null;
+    final canFilterCurrentFree = _isToday;
+    final shouldHideInfo = _showCurrentFreeOnly && currentPeriod == null;
     final rooms = _visibleRooms();
 
     return Column(
@@ -446,12 +451,13 @@ class _ClassroomPageState extends State<ClassroomPage> {
                   ],
                 ),
               ),
-              Text(
-                '${rooms.length} ${l10n.seats == "座" ? "间教室" : "rooms"}',
-                style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+              if (!shouldHideInfo)
+                Text(
+                  '${rooms.length} ${l10n.seats == "座" ? "间教室" : "rooms"}',
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
                 ),
-              ),
             ],
           ),
         ),
@@ -486,12 +492,12 @@ class _ClassroomPageState extends State<ClassroomPage> {
           ),
         ),
         Expanded(
-          child: rooms.isEmpty
+          child: shouldHideInfo
+              ? const SizedBox.shrink()
+              : rooms.isEmpty
               ? Center(
                   child: Text(
-                    _showCurrentFreeOnly && canFilterCurrentFree
-                        ? '当前没有空闲教室'
-                        : l10n.noData,
+                    _showCurrentFreeOnly ? '当前没有空闲教室' : l10n.noData,
                     style: Theme.of(context).textTheme.bodyLarge?.copyWith(
                       color: Theme.of(context).colorScheme.onSurfaceVariant,
                     ),

--- a/lib/pages/campus/classroom/classroom_page.dart
+++ b/lib/pages/campus/classroom/classroom_page.dart
@@ -46,10 +46,15 @@ class _ClassroomPageState extends State<ClassroomPage> {
     super.initState();
     _zhjwApi = getIt<ZhjwApiService>();
     getIt<ScuAuthProvider>().addListener(_onAuthChanged);
+    _startClockTimer();
+    _loadIndex();
+  }
+
+  void _startClockTimer() {
+    _clockTimer?.cancel();
     _clockTimer = Timer.periodic(const Duration(minutes: 1), (_) {
       if (mounted) setState(() {});
     });
-    _loadIndex();
   }
 
   @override
@@ -497,7 +502,7 @@ class _ClassroomPageState extends State<ClassroomPage> {
               : rooms.isEmpty
               ? Center(
                   child: Text(
-                    _showCurrentFreeOnly ? '当前没有空闲教室' : l10n.noData,
+                    _showCurrentFreeOnly ? l10n.noFreeClassrooms : l10n.noData,
                     style: Theme.of(context).textTheme.bodyLarge?.copyWith(
                       color: Theme.of(context).colorScheme.onSurfaceVariant,
                     ),


### PR DESCRIPTION
## 变更内容
- 新增教室列表“当前空闲”筛选
- 使用课表时间段计算当前节次
- 调整空闲态展示逻辑

## 规则说明
- 上课时间映射到对应节次
- 课间映射到下一节
- 第一节前 15 分钟映射到第一节
- 最后一节后不显示
- 选择非今天的日期按钮无法点击

## 验证
- `flutter analyze`
- 手动检查教室页展示
<img width="482" height="1052" alt="image" src="https://github.com/user-attachments/assets/93b2bb3a-a0fa-4f0e-acaa-a90a1bb216e4" />
