### PR TITLE
feat(classroom): 增加节次范围筛选空教室

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -71,6 +71,17 @@
     "classroomCannotBorrow": "Not Borrowable",
     "classroomRemark": "Remark",
     "period": "Period",
+    "periodN": "Period {n}",
+    "@periodN": {
+        "description": "Period number format",
+        "placeholders": {
+            "n": {"type": "int"}
+        }
+    },
+    "periodStart": "Start",
+    "periodEnd": "End",
+    "periodUnlimited": "Any",
+    "clear": "Clear",
     "loading": "Loading...",
     "loadFailed": "Load Failed",
     "retry": "Retry",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -409,6 +409,36 @@ abstract class AppLocalizations {
   /// **'Period'**
   String get period;
 
+  /// Period number format
+  ///
+  /// In en, this message translates to:
+  /// **'Period {n}'**
+  String periodN(int n);
+
+  /// No description provided for @periodStart.
+  ///
+  /// In en, this message translates to:
+  /// **'Start'**
+  String get periodStart;
+
+  /// No description provided for @periodEnd.
+  ///
+  /// In en, this message translates to:
+  /// **'End'**
+  String get periodEnd;
+
+  /// No description provided for @periodUnlimited.
+  ///
+  /// In en, this message translates to:
+  /// **'Any'**
+  String get periodUnlimited;
+
+  /// No description provided for @clear.
+  ///
+  /// In en, this message translates to:
+  /// **'Clear'**
+  String get clear;
+
   /// No description provided for @loading.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -174,6 +174,23 @@ class AppLocalizationsEn extends AppLocalizations {
   String get period => 'Period';
 
   @override
+  String periodN(int n) {
+    return 'Period $n';
+  }
+
+  @override
+  String get periodStart => 'Start';
+
+  @override
+  String get periodEnd => 'End';
+
+  @override
+  String get periodUnlimited => 'Any';
+
+  @override
+  String get clear => 'Clear';
+
+  @override
   String get loading => 'Loading...';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -167,6 +167,23 @@ class AppLocalizationsZh extends AppLocalizations {
   String get period => '节次';
 
   @override
+  String periodN(int n) {
+    return '第 $n 节';
+  }
+
+  @override
+  String get periodStart => '起始';
+
+  @override
+  String get periodEnd => '结束';
+
+  @override
+  String get periodUnlimited => '不限';
+
+  @override
+  String get clear => '清除';
+
+  @override
   String get loading => '加载中...';
 
   @override

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -71,6 +71,17 @@
     "classroomCannotBorrow": "不可借用",
     "classroomRemark": "备注",
     "period": "节次",
+    "periodN": "第 {n} 节",
+    "@periodN": {
+        "description": "节次编号格式",
+        "placeholders": {
+            "n": {"type": "int"}
+        }
+    },
+    "periodStart": "起始",
+    "periodEnd": "结束",
+    "periodUnlimited": "不限",
+    "clear": "清除",
     "loading": "加载中...",
     "loadFailed": "加载失败",
     "retry": "重试",

--- a/lib/pages/campus/classroom/classroom_page.dart
+++ b/lib/pages/campus/classroom/classroom_page.dart
@@ -39,7 +39,8 @@ class _ClassroomPageState extends State<ClassroomPage> {
   bool _isInitialLoad = true;
   LoadErrorType? _error;
   DateTime _selectedDate = DateTime.now();
-  bool _showCurrentFreeOnly = false;
+  int? _filterPeriodStart; // 筛选起始节次 1-12, null=不过滤
+  int? _filterPeriodEnd; // 筛选结束节次 1-12, null=不过滤
 
   @override
   void initState() {
@@ -170,7 +171,7 @@ class _ClassroomPageState extends State<ClassroomPage> {
   }
 
   String _formatDate(DateTime date) {
-    return '${date.year}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}';
+    return '${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}';
   }
 
   bool get _isToday {
@@ -252,20 +253,21 @@ class _ClassroomPageState extends State<ClassroomPage> {
     final result = _queryResult;
     if (result == null) return [];
 
-    final currentPeriod = _currentPeriod();
-    if (!_showCurrentFreeOnly || !_isToday) {
+    final start = _filterPeriodStart;
+    final end = _filterPeriodEnd;
+    if (start == null || end == null || !_isToday) {
       return result.classrooms;
     }
 
-    if (currentPeriod == null) {
-      return [];
-    }
-
     return result.classrooms.where((room) {
-      final status = result.periodStatusMap(
-        room.classroomNumber,
-      )[currentPeriod];
-      return status == null || status == ClassroomPeriodStatus.free;
+      final statusMap = result.periodStatusMap(room.classroomNumber);
+      for (int p = start; p <= end; p++) {
+        final status = statusMap[p];
+        if (status != null && status != ClassroomPeriodStatus.free) {
+          return false;
+        }
+      }
+      return true;
     }).toList();
   }
 
@@ -434,8 +436,7 @@ class _ClassroomPageState extends State<ClassroomPage> {
     if (_queryResult == null) return const SizedBox.shrink();
 
     final currentPeriod = _currentPeriod();
-    final canFilterCurrentFree = _isToday;
-    final shouldHideInfo = _showCurrentFreeOnly && currentPeriod == null;
+    final hasFilter = _filterPeriodStart != null;
     final rooms = _visibleRooms();
 
     return Column(
@@ -462,21 +463,22 @@ class _ClassroomPageState extends State<ClassroomPage> {
                   ],
                 ),
               ),
-              if (!shouldHideInfo)
-                Text(
-                  '${rooms.length} ${l10n.seats == "座" ? "间教室" : "rooms"}',
-                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                    color: Theme.of(context).colorScheme.onSurfaceVariant,
-                  ),
+              Text(
+                '${rooms.length} ${l10n.seats == "座" ? "间教室" : "rooms"}',
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
                 ),
+              ),
             ],
           ),
         ),
+        // ── 日期与节次筛选 ─────────────────────────────────
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16),
           child: Wrap(
             spacing: 8,
             runSpacing: 8,
+            crossAxisAlignment: WrapCrossAlignment.center,
             children: [
               ActionChip(
                 avatar: const Icon(Icons.calendar_today, size: 18),
@@ -486,29 +488,83 @@ class _ClassroomPageState extends State<ClassroomPage> {
               if (!_isToday) ...[
                 ActionChip(label: Text(l10n.today), onPressed: _goToToday),
               ],
-              FilterChip(
-                avatar: const Icon(Icons.filter_alt_outlined, size: 18),
-                label: Text('${l10n.current}${l10n.free}'),
-                selected: _showCurrentFreeOnly && canFilterCurrentFree,
-                onSelected: canFilterCurrentFree
-                    ? (selected) {
-                        setState(() {
-                          _showCurrentFreeOnly = selected;
-                        });
-                      }
-                    : null,
-                showCheckmark: false,
-              ),
+              if (_isToday)
+                FilterChip(
+                  avatar: const Icon(Icons.access_time, size: 18),
+                  label: Text('${l10n.current}${l10n.free}'),
+                  selected:
+                      _filterPeriodStart == currentPeriod &&
+                      _filterPeriodEnd == currentPeriod,
+                  showCheckmark: false,
+                  onSelected: currentPeriod != null
+                      ? (selected) {
+                          setState(() {
+                            if (selected) {
+                              _filterPeriodStart = currentPeriod;
+                              _filterPeriodEnd = currentPeriod;
+                            } else {
+                              _clearPeriodFilter();
+                            }
+                          });
+                        }
+                      : null,
+                ),
             ],
           ),
         ),
+        if (_isToday) ...[
+          const SizedBox(height: 8),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              crossAxisAlignment: WrapCrossAlignment.center,
+              children: [
+                _buildPeriodDropdown(
+                  l10n: l10n,
+                  label: l10n.periodStart,
+                  value: _filterPeriodStart,
+                  onChanged: (v) {
+                    setState(() {
+                      _filterPeriodStart = v;
+                      if (v != null &&
+                          (_filterPeriodEnd == null || v > _filterPeriodEnd!)) {
+                        _filterPeriodEnd = v;
+                      }
+                    });
+                  },
+                ),
+                const Text('→'),
+                _buildPeriodDropdown(
+                  l10n: l10n,
+                  label: l10n.periodEnd,
+                  value: _filterPeriodEnd,
+                  onChanged: (v) {
+                    setState(() {
+                      _filterPeriodEnd = v;
+                      if (v != null &&
+                          (_filterPeriodStart == null ||
+                              v < _filterPeriodStart!)) {
+                        _filterPeriodStart = v;
+                      }
+                    });
+                  },
+                ),
+                if (hasFilter)
+                  ActionChip(
+                    label: Text(l10n.clear),
+                    onPressed: _clearPeriodFilter,
+                  ),
+              ],
+            ),
+          ),
+        ],
         Expanded(
-          child: shouldHideInfo
-              ? const SizedBox.shrink()
-              : rooms.isEmpty
+          child: rooms.isEmpty
               ? Center(
                   child: Text(
-                    _showCurrentFreeOnly ? l10n.noFreeClassrooms : l10n.noData,
+                    hasFilter ? l10n.noFreeClassrooms : l10n.noData,
                     style: Theme.of(context).textTheme.bodyLarge?.copyWith(
                       color: Theme.of(context).colorScheme.onSurfaceVariant,
                     ),
@@ -674,5 +730,57 @@ class _ClassroomPageState extends State<ClassroomPage> {
       case ClassroomPeriodStatus.borrowed:
         return Colors.amber;
     }
+  }
+
+  void _clearPeriodFilter() {
+    setState(() {
+      _filterPeriodStart = null;
+      _filterPeriodEnd = null;
+    });
+  }
+
+  Widget _buildPeriodDropdown({
+    required AppLocalizations l10n,
+    required String label,
+    required int? value,
+    required ValueChanged<int?> onChanged,
+  }) {
+    return PopupMenuButton<int?>(
+      onSelected: onChanged,
+      padding: EdgeInsets.zero,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+      child: SizedBox(
+        height: 32,
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 12),
+          decoration: ShapeDecoration(
+            color: Theme.of(context).colorScheme.surfaceContainerHigh,
+            shape: StadiumBorder(),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                value != null ? l10n.periodN(value) : label,
+                style: Theme.of(context).textTheme.labelMedium,
+              ),
+              const SizedBox(width: 2),
+              Icon(
+                Icons.arrow_drop_down,
+                size: 18,
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
+            ],
+          ),
+        ),
+      ),
+      itemBuilder: (context) => [
+        PopupMenuItem<int?>(value: null, child: Text(l10n.periodUnlimited)),
+        ...List.generate(12, (i) {
+          final p = i + 1;
+          return PopupMenuItem<int?>(value: p, child: Text(l10n.periodN(p)));
+        }),
+      ],
+    );
   }
 }

--- a/lib/pages/campus/classroom/classroom_page.dart
+++ b/lib/pages/campus/classroom/classroom_page.dart
@@ -472,94 +472,69 @@ class _ClassroomPageState extends State<ClassroomPage> {
             ],
           ),
         ),
-        // ── 日期与节次筛选 ─────────────────────────────────
+        // ── 紧凑筛选栏 ─────────────────────────────────
         Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16),
-          child: Wrap(
-            spacing: 8,
-            runSpacing: 8,
-            crossAxisAlignment: WrapCrossAlignment.center,
-            children: [
-              ActionChip(
-                avatar: const Icon(Icons.calendar_today, size: 18),
-                label: Text(_formatDate(_selectedDate)),
-                onPressed: _pickDate,
-              ),
-              if (!_isToday) ...[
-                ActionChip(label: Text(l10n.today), onPressed: _goToToday),
-              ],
-              if (_isToday)
-                FilterChip(
-                  avatar: const Icon(Icons.access_time, size: 18),
-                  label: Text('${l10n.current}${l10n.free}'),
-                  selected:
-                      _filterPeriodStart == currentPeriod &&
-                      _filterPeriodEnd == currentPeriod,
-                  showCheckmark: false,
-                  onSelected: currentPeriod != null
-                      ? (selected) {
-                          setState(() {
-                            if (selected) {
-                              _filterPeriodStart = currentPeriod;
-                              _filterPeriodEnd = currentPeriod;
-                            } else {
-                              _clearPeriodFilter();
-                            }
-                          });
-                        }
-                      : null,
-                ),
-            ],
-          ),
-        ),
-        if (_isToday) ...[
-          const SizedBox(height: 8),
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16),
-            child: Wrap(
-              spacing: 8,
-              runSpacing: 8,
-              crossAxisAlignment: WrapCrossAlignment.center,
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
+          child: SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: Row(
               children: [
-                _buildPeriodDropdown(
-                  l10n: l10n,
-                  label: l10n.periodStart,
-                  value: _filterPeriodStart,
-                  onChanged: (v) {
-                    setState(() {
-                      _filterPeriodStart = v;
-                      if (v != null &&
-                          (_filterPeriodEnd == null || v > _filterPeriodEnd!)) {
-                        _filterPeriodEnd = v;
-                      }
-                    });
-                  },
+                ActionChip(
+                  avatar: const Icon(Icons.calendar_today, size: 16),
+                  label: Text(_formatDate(_selectedDate)),
+                  onPressed: _pickDate,
+                  visualDensity: VisualDensity.compact,
                 ),
-                const Text('→'),
-                _buildPeriodDropdown(
-                  l10n: l10n,
-                  label: l10n.periodEnd,
-                  value: _filterPeriodEnd,
-                  onChanged: (v) {
-                    setState(() {
-                      _filterPeriodEnd = v;
-                      if (v != null &&
-                          (_filterPeriodStart == null ||
-                              v < _filterPeriodStart!)) {
-                        _filterPeriodStart = v;
-                      }
-                    });
-                  },
-                ),
-                if (hasFilter)
+                const SizedBox(width: 6),
+                if (!_isToday)
+                  ActionChip(
+                    label: Text(l10n.today),
+                    onPressed: _goToToday,
+                    visualDensity: VisualDensity.compact,
+                  ),
+                if (!_isToday) const SizedBox(width: 6),
+                if (_isToday)
+                  FilterChip(
+                    avatar: const Icon(Icons.access_time, size: 16),
+                    label: Text(l10n.free),
+                    selected:
+                        _filterPeriodStart == currentPeriod &&
+                        _filterPeriodEnd == currentPeriod,
+                    showCheckmark: false,
+                    visualDensity: VisualDensity.compact,
+                    onSelected: currentPeriod != null
+                        ? (selected) {
+                            setState(() {
+                              if (selected) {
+                                _filterPeriodStart = currentPeriod;
+                                _filterPeriodEnd = currentPeriod;
+                              } else {
+                                _clearPeriodFilter();
+                              }
+                            });
+                          }
+                        : null,
+                  ),
+                if (_isToday) const SizedBox(width: 6),
+                if (_isToday)
+                  ActionChip(
+                    avatar: const Icon(Icons.format_list_numbered, size: 16),
+                    label: Text(_periodRangeLabel(l10n)),
+                    onPressed: () => _showPeriodRangeDialog(l10n),
+                    visualDensity: VisualDensity.compact,
+                  ),
+                if (hasFilter) ...[
+                  const SizedBox(width: 6),
                   ActionChip(
                     label: Text(l10n.clear),
                     onPressed: _clearPeriodFilter,
+                    visualDensity: VisualDensity.compact,
                   ),
+                ],
               ],
             ),
           ),
-        ],
+        ),
         Expanded(
           child: rooms.isEmpty
               ? Center(
@@ -739,48 +714,94 @@ class _ClassroomPageState extends State<ClassroomPage> {
     });
   }
 
-  Widget _buildPeriodDropdown({
-    required AppLocalizations l10n,
-    required String label,
-    required int? value,
-    required ValueChanged<int?> onChanged,
-  }) {
-    return PopupMenuButton<int?>(
-      onSelected: onChanged,
-      padding: EdgeInsets.zero,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
-      child: SizedBox(
-        height: 32,
-        child: Container(
-          padding: const EdgeInsets.symmetric(horizontal: 12),
-          decoration: ShapeDecoration(
-            color: Theme.of(context).colorScheme.surfaceContainerHigh,
-            shape: StadiumBorder(),
-          ),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Text(
-                value != null ? l10n.periodN(value) : label,
-                style: Theme.of(context).textTheme.labelMedium,
+  String _periodRangeLabel(AppLocalizations l10n) {
+    if (_filterPeriodStart == null || _filterPeriodEnd == null) {
+      return l10n.periodUnlimited;
+    }
+    if (_filterPeriodStart == _filterPeriodEnd) {
+      return l10n.periodN(_filterPeriodStart!);
+    }
+    return '${l10n.periodN(_filterPeriodStart!)}-${l10n.periodN(_filterPeriodEnd!)}';
+  }
+
+  Future<void> _showPeriodRangeDialog(AppLocalizations l10n) async {
+    int start = _filterPeriodStart ?? 1;
+    int end = _filterPeriodEnd ?? 12;
+    final result = await showDialog<Map<String, int>>(
+      context: context,
+      builder: (context) {
+        final dialogL10n = AppLocalizations.of(context)!;
+        return StatefulBuilder(
+          builder: (context, setDialogState) => AlertDialog(
+            title: Text(dialogL10n.period),
+            content: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Row(
+                  children: [
+                    Text('${dialogL10n.periodStart}: '),
+                    DropdownButton<int>(
+                      value: start,
+                      items: List.generate(
+                        12,
+                        (i) => DropdownMenuItem(
+                          value: i + 1,
+                          child: Text(dialogL10n.periodN(i + 1)),
+                        ),
+                      ),
+                      onChanged: (v) {
+                        setDialogState(() {
+                          start = v!;
+                          if (start > end) end = start;
+                        });
+                      },
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                Row(
+                  children: [
+                    Text('${dialogL10n.periodEnd}: '),
+                    DropdownButton<int>(
+                      value: end,
+                      items: List.generate(
+                        12,
+                        (i) => DropdownMenuItem(
+                          value: i + 1,
+                          child: Text(dialogL10n.periodN(i + 1)),
+                        ),
+                      ),
+                      onChanged: (v) {
+                        setDialogState(() {
+                          end = v!;
+                          if (end < start) start = end;
+                        });
+                      },
+                    ),
+                  ],
+                ),
+              ],
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(context),
+                child: Text(dialogL10n.cancel),
               ),
-              const SizedBox(width: 2),
-              Icon(
-                Icons.arrow_drop_down,
-                size: 18,
-                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              FilledButton(
+                onPressed: () =>
+                    Navigator.pop(context, {'start': start, 'end': end}),
+                child: Text(dialogL10n.confirm),
               ),
             ],
           ),
-        ),
-      ),
-      itemBuilder: (context) => [
-        PopupMenuItem<int?>(value: null, child: Text(l10n.periodUnlimited)),
-        ...List.generate(12, (i) {
-          final p = i + 1;
-          return PopupMenuItem<int?>(value: p, child: Text(l10n.periodN(p)));
-        }),
-      ],
+        );
+      },
     );
+    if (result != null) {
+      setState(() {
+        _filterPeriodStart = result['start']!;
+        _filterPeriodEnd = result['end']!;
+      });
+    }
   }
 }

--- a/lib/pages/dev/changelog/changelog_page.dart
+++ b/lib/pages/dev/changelog/changelog_page.dart
@@ -100,7 +100,7 @@ class _ChangelogPageState extends State<ChangelogPage> {
           : ListView.separated(
               padding: const EdgeInsets.symmetric(vertical: 8),
               itemCount: _entries.length,
-              separatorBuilder: (_, __) => const Divider(height: 1, indent: 72),
+              separatorBuilder: (_, _) => const Divider(height: 1, indent: 72),
               itemBuilder: (context, index) {
                 final entry = _entries[index];
                 final isUnreleased = entry.version == 'Unreleased';

--- a/lib/widgets/dialog/update_dialog.dart
+++ b/lib/widgets/dialog/update_dialog.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 import 'package:bugaoshan/pages/about/release_notes_page.dart';
 import 'package:bugaoshan/widgets/route/router_utils.dart';
 import 'package:flutter/material.dart';


### PR DESCRIPTION
## 功能：教室节次范围筛选

### 变更背景

原「当前空闲」仅为简单的单节次筛选开关，无法满足更灵活的查询需求（如查第3-5节都空闲的教室）。此 PR 将该开关改造为完整的节次范围筛选器。

### 变更内容

#### 核心逻辑
- 状态变量：`_showCurrentFreeOnly` (bool) → `_filterPeriodStart`/`_filterPeriodEnd` (int?, 1-12, null=不过滤)
- 筛选逻辑：遍历 `[start, end]` 范围内全部节次均为空闲才显示该教室

#### UI 交互
- **第一行**：📅 日期选择 · ⏰ 当前空闲（原有）
- **第二行**：🡇 起始下拉 → 🡇 结束下拉 · ✕ 清除
  - 起始/结束联动防无效范围
  - 下拉菜单支持「不限」选项，可单独取消一端
- 全部 5 个控件统一为 `StadiumBorder` 圆角 + 32px 等高三芯片风格

#### 国际化
- l10n

#### 代码清理
- 删除 `shouldHideInfo` 特殊分支，统一空状态逻辑
- 硬编码样式（`fontSize: 13`、`borderRadius: 20`）替换为主题 token