### PR TITLE
fix: 修复认证、并发状态与发布链路问题

### DIFF
--- a/.github/scripts/release_body.py
+++ b/.github/scripts/release_body.py
@@ -9,7 +9,10 @@ def main():
     prev = os.environ.get("PREV", "").lstrip("v")
 
     body = f"""## ⬇️ 下载 (Downloads)
-- Android: [arm64 APK]({repo}/releases/download/v{version}/bugaoshan_{version}_arm64-v8a.apk)
+- Android: [通用 APK]({repo}/releases/download/v{version}/bugaoshan_{version}_universal.apk)
+  - [arm64-v8a]({repo}/releases/download/v{version}/bugaoshan_{version}_arm64-v8a.apk)
+  - [armeabi-v7a]({repo}/releases/download/v{version}/bugaoshan_{version}_armeabi-v7a.apk)
+  - [x86_64]({repo}/releases/download/v{version}/bugaoshan_{version}_x86_64.apk)
 - Windows: [x64 Zip]({repo}/releases/download/v{version}/bugaoshan_{version}_windows_x64.zip)
 - Linux: [x64 Tar.gz]({repo}/releases/download/v{version}/bugaoshan_{version}_linux_x64.tar.gz)
 

--- a/.github/scripts/release_prepare.py
+++ b/.github/scripts/release_prepare.py
@@ -1,28 +1,53 @@
 """Prepare release files for upload."""
 
 import os
-import glob
 import shutil
+from pathlib import Path
+
+
+def _android_asset_suffix(filename):
+    if filename in ("app-release.apk", "app-universal-release.apk"):
+        return "universal"
+    prefix = "app-"
+    suffix = "-release.apk"
+    if filename.startswith(prefix) and filename.endswith(suffix):
+        return filename[len(prefix) : -len(suffix)]
+    return None
+
+
+def prepare_release_files(version, root=Path(".")):
+    root = Path(root)
+    version = version.lstrip("v")
+    android_dir = root / "android-apk"
+
+    universal = android_dir / "app-universal-release.apk"
+    raw_universal = android_dir / "app-release.apk"
+    if not universal.exists() and not raw_universal.exists():
+        raise FileNotFoundError("Missing universal Android updater APK")
+
+    for apk in sorted(android_dir.glob("*.apk")):
+        arch = _android_asset_suffix(apk.name)
+        if arch is None:
+            continue
+        if arch == "universal" and apk == raw_universal and universal.exists():
+            continue
+        dst = root / f"bugaoshan_{version}_{arch}.apk"
+        shutil.copy2(apk, dst)
+        print(f"Copied {apk} -> {dst}")
+
+    windows_src = root / "windows-release" / "windows-release.zip"
+    shutil.copy2(windows_src, root / f"bugaoshan_{version}_windows_x64.zip")
+    print("Copied windows artifact")
+
+    linux_src = root / "linux-release" / "linux-release.tar.gz"
+    shutil.copy2(linux_src, root / f"bugaoshan_{version}_linux_x64.tar.gz")
+    print("Copied linux artifact")
+
 
 def main():
     version = os.environ.get("VERSION", "")
-    version = version.lstrip("v")
+    prepare_release_files(version)
 
-    # Rename APKs
-    for apk in glob.glob("android-apk/*.apk"):
-        filename = os.path.basename(apk)
-        arch = filename.replace("app-", "").replace("-release.apk", "")
-        dst = f"bugaoshan_{version}_{arch}.apk"
-        shutil.copy(apk, dst)
-        print(f"Copied {apk} -> {dst}")
-
-    # Copy zip and tar.gz
-    shutil.copy("windows-release/windows-release.zip", f"bugaoshan_{version}_windows_x64.zip")
-    print("Copied windows artifact")
-
-    linux_src = "linux-release/linux-release.tar.gz"
-    shutil.copy(linux_src, f"bugaoshan_{version}_linux_x64.tar.gz")
-    print("Copied linux artifact")
 
 if __name__ == "__main__":
     main()

--- a/.github/scripts/release_prepare.py
+++ b/.github/scripts/release_prepare.py
@@ -21,11 +21,8 @@ def main():
     print("Copied windows artifact")
 
     linux_src = "linux-release/linux-release.tar.gz"
-    if os.path.exists(linux_src):
-        shutil.copy(linux_src, f"bugaoshan_{version}_linux_x64.tar.gz")
-        print("Copied linux artifact")
-    else:
-        print(f"Skipped linux artifact (not found: {linux_src})")
+    shutil.copy(linux_src, f"bugaoshan_{version}_linux_x64.tar.gz")
+    print("Copied linux artifact")
 
 if __name__ == "__main__":
     main()

--- a/.github/scripts/test_release_prepare.py
+++ b/.github/scripts/test_release_prepare.py
@@ -1,0 +1,58 @@
+"""Tests for release artifact preparation."""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import release_prepare
+
+
+class ReleasePrepareTest(unittest.TestCase):
+    def test_keeps_universal_and_split_android_packages(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            android_dir = root / "android-apk"
+            windows_dir = root / "windows-release"
+            linux_dir = root / "linux-release"
+            android_dir.mkdir()
+            windows_dir.mkdir()
+            linux_dir.mkdir()
+
+            packages = {
+                "app-universal-release.apk": b"universal",
+                "app-arm64-v8a-release.apk": b"arm64",
+                "app-armeabi-v7a-release.apk": b"armv7",
+                "app-x86_64-release.apk": b"x64",
+            }
+            for name, content in packages.items():
+                (android_dir / name).write_bytes(content)
+            (windows_dir / "windows-release.zip").write_bytes(b"windows")
+            (linux_dir / "linux-release.tar.gz").write_bytes(b"linux")
+
+            release_prepare.prepare_release_files("v2.2.0", root=root)
+
+            expected = {
+                "bugaoshan_2.2.0_universal.apk": b"universal",
+                "bugaoshan_2.2.0_arm64-v8a.apk": b"arm64",
+                "bugaoshan_2.2.0_armeabi-v7a.apk": b"armv7",
+                "bugaoshan_2.2.0_x86_64.apk": b"x64",
+            }
+            for name, content in expected.items():
+                self.assertEqual((root / name).read_bytes(), content)
+
+    def test_requires_the_universal_updater_package(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            android_dir = root / "android-apk"
+            windows_dir = root / "windows-release"
+            android_dir.mkdir()
+            windows_dir.mkdir()
+            (android_dir / "app-arm64-v8a-release.apk").write_bytes(b"arm64")
+            (windows_dir / "windows-release.zip").write_bytes(b"windows")
+
+            with self.assertRaises(FileNotFoundError):
+                release_prepare.prepare_release_files("v2.2.0", root=root)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/tests/test_release_workflow.py
+++ b/.github/scripts/tests/test_release_workflow.py
@@ -1,0 +1,35 @@
+import unittest
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+
+
+class ReleaseWorkflowTest(unittest.TestCase):
+    def test_linux_artifact_is_built_downloaded_and_required(self):
+        workflow = (REPOSITORY_ROOT / ".github/workflows/release.yml").read_text(
+            encoding="utf-8"
+        )
+        prepare_script = (
+            REPOSITORY_ROOT / ".github/scripts/release_prepare.py"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn(
+            "  build-linux:\n    uses: ./.github/workflows/build-linux.yml",
+            workflow,
+        )
+        self.assertIn(
+            "needs: [ build-android, build-windows, build-linux ]",
+            workflow,
+        )
+        self.assertIn("name: linux-release", workflow)
+        self.assertIn("path: linux-release", workflow)
+
+        # 发布正文固定提供 Linux 链接，因此制品缺失必须令准备步骤失败，
+        # 不能静默跳过后继续发布一个失效链接。
+        self.assertNotIn("if os.path.exists(linux_src)", prepare_script)
+        self.assertNotIn("Skipped linux artifact", prepare_script)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -48,17 +48,30 @@ jobs:
           echo 'keyAlias=${{ secrets.KEY_ALIAS }}' >> android/key.properties
           echo 'storeFile=../keystore/upload-keystore.jks' >> android/key.properties
 
-      - name: Build APK
+      - name: Build universal APK for in-app updates
         run: |
-          flutter build apk --release --split-per-abi \
-            --obfuscate --split-debug-info=build/app/outputs/symbols \
+          flutter build apk --release \
+            --obfuscate --split-debug-info=build/app/outputs/symbols/universal \
             --dart-define=GIT_TAG=${{ steps.setup.outputs.GIT_TAG }} \
             --dart-define=GIT_COMMIT=${{ steps.setup.outputs.GIT_COMMIT }} \
             --dart-define=GIT_COMMIT_DATE=${{ steps.setup.outputs.GIT_COMMIT_DATE }} \
             --dart-define=BUILD_TIME=${{ steps.setup.outputs.BUILD_TIME }}
+          mkdir -p release-apks
+          cp build/app/outputs/flutter-apk/app-release.apk \
+            release-apks/app-universal-release.apk
 
-      - name: Upload APK
+      - name: Build ABI split APKs for manual downloads
+        run: |
+          flutter build apk --release --split-per-abi \
+            --obfuscate --split-debug-info=build/app/outputs/symbols/split \
+            --dart-define=GIT_TAG=${{ steps.setup.outputs.GIT_TAG }} \
+            --dart-define=GIT_COMMIT=${{ steps.setup.outputs.GIT_COMMIT }} \
+            --dart-define=GIT_COMMIT_DATE=${{ steps.setup.outputs.GIT_COMMIT_DATE }} \
+            --dart-define=BUILD_TIME=${{ steps.setup.outputs.BUILD_TIME }}
+          cp build/app/outputs/flutter-apk/app-*-release.apk release-apks/
+
+      - name: Upload universal and split APKs
         uses: actions/upload-artifact@v4
         with:
           name: android-apk
-          path: build/app/outputs/flutter-apk/*.apk
+          path: release-apks/*.apk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,15 @@ jobs:
       version: ${{ github.event.inputs.version }}
     secrets: inherit
 
+  build-linux:
+    uses: ./.github/workflows/build-linux.yml
+    with:
+      version: ${{ github.event.inputs.version }}
+    secrets: inherit
+
   release:
     name: Release
-    needs: [ build-android, build-windows ]
+    needs: [ build-android, build-windows, build-linux ]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/') || github.event_name ==
       'workflow_dispatch'
@@ -50,6 +56,12 @@ jobs:
         with:
           name: windows-release
           path: windows-release
+
+      - name: Download Linux
+        uses: actions/download-artifact@v4
+        with:
+          name: linux-release
+          path: linux-release
 
       - name: Set up Python 3
         uses: actions/setup-python@v3

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -77,6 +77,7 @@ android {
 dependencies {
     implementation("androidx.glance:glance-appwidget:1.1.1")
     implementation("androidx.work:work-runtime-ktx:2.11.2")
+    testImplementation(kotlin("test"))
 }
 
 flutter {

--- a/android/app/src/main/kotlin/io/github/the_brotherhood_of_scu/bugaoshan/CourseGlanceWidget.kt
+++ b/android/app/src/main/kotlin/io/github/the_brotherhood_of_scu/bugaoshan/CourseGlanceWidget.kt
@@ -169,10 +169,10 @@ object WidgetDataLoader {
             val currentWeek = computeCurrentWeek(semesterStartDate, totalWeeks)
             val cal = Calendar.getInstance()
             val dayOfWeek = (cal.get(Calendar.DAY_OF_WEEK) + 5) % 7 + 1
-            var courses = queryCourses(db, currentScheduleId, dayOfWeek, currentWeek)
-            if (courses.length() == 0 && currentScheduleId != "default") {
-                courses = queryCourses(db, "default", dayOfWeek, currentWeek)
-            }
+            var courses =
+                loadCoursesForSelectedSchedule(currentScheduleId) { scheduleId ->
+                    queryCourses(db, scheduleId, dayOfWeek, currentWeek)
+                }
             val now = Calendar.getInstance()
             val currentHour = now.get(Calendar.HOUR_OF_DAY)
             val currentMinute = now.get(Calendar.MINUTE)
@@ -194,10 +194,10 @@ object WidgetDataLoader {
                         tomorrowCal = Calendar.getInstance().apply { add(Calendar.DATE, 1) }
                         val nextDayOfWeek = (tomorrowCal!!.get(Calendar.DAY_OF_WEEK) + 5) % 7 + 1
                         weekForTomorrow = computeWeekForDate(semesterStartDate, totalWeeks, tomorrowCal!!)
-                        var tomorrowCourses = queryCourses(db, currentScheduleId, nextDayOfWeek, weekForTomorrow)
-                        if (tomorrowCourses.length() == 0 && currentScheduleId != "default") {
-                            tomorrowCourses = queryCourses(db, "default", nextDayOfWeek, weekForTomorrow)
-                        }
+                        val tomorrowCourses =
+                            loadCoursesForSelectedSchedule(currentScheduleId) { scheduleId ->
+                                queryCourses(db, scheduleId, nextDayOfWeek, weekForTomorrow)
+                            }
                         if (tomorrowCourses.length() > 0) {
                             courses = attachTimesAndStatuses(tomorrowCourses, timeSlots, null, true)
                             showingTomorrow = true

--- a/android/app/src/main/kotlin/io/github/the_brotherhood_of_scu/bugaoshan/WidgetCourseSelection.kt
+++ b/android/app/src/main/kotlin/io/github/the_brotherhood_of_scu/bugaoshan/WidgetCourseSelection.kt
@@ -1,0 +1,11 @@
+package io.github.the_brotherhood_of_scu.bugaoshan
+
+/**
+ * 只读取用户当前选中的课表。
+ *
+ * 查询结果为空表示该课表当天确实没有课程，不能据此改查其他课表。
+ */
+internal inline fun <T> loadCoursesForSelectedSchedule(
+    selectedScheduleId: String,
+    query: (String) -> T,
+): T = query(selectedScheduleId)

--- a/android/app/src/test/kotlin/io/github/the_brotherhood_of_scu/bugaoshan/WidgetCourseSelectionTest.kt
+++ b/android/app/src/test/kotlin/io/github/the_brotherhood_of_scu/bugaoshan/WidgetCourseSelectionTest.kt
@@ -1,0 +1,21 @@
+package io.github.the_brotherhood_of_scu.bugaoshan
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class WidgetCourseSelectionTest {
+    @Test
+    fun emptyCurrentScheduleDoesNotQueryDefaultSchedule() {
+        val queriedScheduleIds = mutableListOf<String>()
+
+        val courses =
+            loadCoursesForSelectedSchedule("empty-selected") { scheduleId ->
+                queriedScheduleIds += scheduleId
+                emptyList<String>()
+            }
+
+        assertTrue(courses.isEmpty())
+        assertEquals(listOf("empty-selected"), queriedScheduleIds)
+    }
+}

--- a/lib/injection/injector.dart
+++ b/lib/injection/injector.dart
@@ -171,18 +171,22 @@ void _configureAsyncDependencies() {
     await getIt.isReady<SharedPreferences>();
     await getIt.isReady<ZhjwApiService>();
     await getIt.isReady<ScuAuthProvider>();
+    await getIt.isReady<ScuAuth>();
     final prefs = getIt<SharedPreferences>();
     final zhjwApi = getIt<ZhjwApiService>();
     final authProvider = getIt<ScuAuthProvider>();
+    final scuAuth = getIt<ScuAuth>();
+    String? currentIdentity() => GradesProvider.confirmedUserIdentity(
+      isLoggedIn: authProvider.isLoggedIn,
+      principal: scuAuth.principal,
+    );
     final gradesProvider = GradesProvider(
       prefs,
       zhjwApi,
-      initialUserId: authProvider.isLoggedIn ? authProvider.userNumber : null,
+      initialUserId: currentIdentity(),
     );
     authProvider.addListener(() {
-      gradesProvider.setUserIdentity(
-        authProvider.isLoggedIn ? authProvider.userNumber : null,
-      );
+      gradesProvider.setUserIdentity(currentIdentity());
     });
     return gradesProvider;
   });

--- a/lib/injection/injector.dart
+++ b/lib/injection/injector.dart
@@ -170,9 +170,21 @@ void _configureAsyncDependencies() {
   getIt.registerSingletonAsync<GradesProvider>(() async {
     await getIt.isReady<SharedPreferences>();
     await getIt.isReady<ZhjwApiService>();
+    await getIt.isReady<ScuAuthProvider>();
     final prefs = getIt<SharedPreferences>();
     final zhjwApi = getIt<ZhjwApiService>();
-    return GradesProvider(prefs, zhjwApi);
+    final authProvider = getIt<ScuAuthProvider>();
+    final gradesProvider = GradesProvider(
+      prefs,
+      zhjwApi,
+      initialUserId: authProvider.isLoggedIn ? authProvider.userNumber : null,
+    );
+    authProvider.addListener(() {
+      gradesProvider.setUserIdentity(
+        authProvider.isLoggedIn ? authProvider.userNumber : null,
+      );
+    });
+    return gradesProvider;
   });
   getIt.registerSingletonAsync<TrainProgramProvider>(() async {
     await getIt.isReady<ZhjwApiService>();

--- a/lib/models/course.dart
+++ b/lib/models/course.dart
@@ -347,6 +347,26 @@ class ScheduleConfig {
     return week.clamp(1, totalWeeks);
   }
 
+  /// 返回指定教学周、星期对应的自然日。
+  ///
+  /// 课表允许将学期起点保存为周日；该周日属于第一教学周，随后一天
+  /// 才是第一周周一。因此不能直接用 [DateTimeExtension.toMonday]，否则
+  /// 周日起点会被归到前一周。
+  DateTime dateForCourseDay(int week, int dayOfWeek) {
+    final start = DateTime(
+      semesterStartDate.year,
+      semesterStartDate.month,
+      semesterStartDate.day,
+    );
+    final mondayOffset = (DateTime.monday - start.weekday) % 7;
+    final daysFromMonday = dayOfWeek == DateTime.sunday
+        ? -1
+        : dayOfWeek - DateTime.monday;
+    return start.add(
+      Duration(days: (week - 1) * 7 + mondayOffset + daysFromMonday),
+    );
+  }
+
   ScheduleConfig copyWith({
     String? id,
     String? semesterName,

--- a/lib/pages/campus/academic_calendar/academic_calendar_page.dart
+++ b/lib/pages/campus/academic_calendar/academic_calendar_page.dart
@@ -14,16 +14,20 @@ import 'official_calendar_view.dart';
 
 typedef AcademicCalendarHttpGet = Future<http.Response> Function(Uri uri);
 typedef AcademicCalendarDataLoader = Future<AcademicCalendarData> Function();
+typedef AcademicCalendarImageBuilder =
+    Widget Function(BuildContext context, String url);
 
 class AcademicCalendarPage extends StatefulWidget {
   const AcademicCalendarPage({
     super.key,
     this.httpGet,
     this.interactiveDataLoader,
+    this.officialImageBuilder,
   });
 
   final AcademicCalendarHttpGet? httpGet;
   final AcademicCalendarDataLoader? interactiveDataLoader;
+  final AcademicCalendarImageBuilder? officialImageBuilder;
 
   @override
   State<AcademicCalendarPage> createState() => _AcademicCalendarPageState();
@@ -41,6 +45,7 @@ class _AcademicCalendarPageState extends State<AcademicCalendarPage>
   List<CalendarEntry> _entries = [];
   List<String> _imageUrls = [];
   CalendarEntry? _selected;
+  int _detailRequestGeneration = 0;
 
   // Interactive Calendar variables
   bool _interactiveLoading = true;
@@ -65,6 +70,7 @@ class _AcademicCalendarPageState extends State<AcademicCalendarPage>
 
   @override
   void dispose() {
+    _detailRequestGeneration++;
     _tabController.removeListener(_handleTabChange);
     _tabController.dispose();
     super.dispose();
@@ -125,6 +131,7 @@ class _AcademicCalendarPageState extends State<AcademicCalendarPage>
 
   Future<void> _loadDetail(CalendarEntry entry) async {
     if (!mounted) return;
+    final requestGeneration = ++_detailRequestGeneration;
     setState(() {
       _loading = true;
       _error = null;
@@ -135,7 +142,7 @@ class _AcademicCalendarPageState extends State<AcademicCalendarPage>
       final uri = Uri.parse('$_base/${entry.path}');
       final request = widget.httpGet?.call(uri) ?? http.get(uri);
       final resp = await request.timeout(const Duration(seconds: 8));
-      if (!mounted) return;
+      if (!_isCurrentDetailRequest(requestGeneration, entry)) return;
       if (resp.statusCode != 200) {
         throw Exception('HTTP ${resp.statusCode}');
       }
@@ -154,20 +161,24 @@ class _AcademicCalendarPageState extends State<AcademicCalendarPage>
         throw Exception('No images found');
       }
 
-      if (mounted) {
-        setState(() {
-          _imageUrls = urls;
-          _loading = false;
-        });
-      }
+      if (!_isCurrentDetailRequest(requestGeneration, entry)) return;
+      setState(() {
+        _imageUrls = urls;
+        _loading = false;
+      });
     } catch (e) {
-      if (mounted) {
-        setState(() {
-          _loading = false;
-          _error = e.toString();
-        });
-      }
+      if (!_isCurrentDetailRequest(requestGeneration, entry)) return;
+      setState(() {
+        _loading = false;
+        _error = e.toString();
+      });
     }
+  }
+
+  bool _isCurrentDetailRequest(int generation, CalendarEntry entry) {
+    return mounted &&
+        generation == _detailRequestGeneration &&
+        identical(entry, _selected);
   }
 
   // Fetch interactive calendar data
@@ -283,6 +294,7 @@ class _AcademicCalendarPageState extends State<AcademicCalendarPage>
             loading: _loading,
             error: _error,
             imageUrls: _imageUrls,
+            imageBuilder: widget.officialImageBuilder,
             onEntryChanged: (entry) {
               setState(() => _selected = entry);
               _loadDetail(entry);

--- a/lib/pages/campus/academic_calendar/academic_calendar_page.dart
+++ b/lib/pages/campus/academic_calendar/academic_calendar_page.dart
@@ -1,18 +1,29 @@
 import 'dart:convert';
+
 import 'package:flutter/material.dart';
-import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:http/http.dart' as http;
 
 import 'package:bugaoshan/injection/injector.dart';
+import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/models/academic_calendar.dart';
 import 'package:bugaoshan/services/api/academic_calendar_service.dart';
 import 'package:bugaoshan/utils/calendar_export_utils.dart';
 
-import 'official_calendar_view.dart';
 import 'interactive_calendar_view.dart';
+import 'official_calendar_view.dart';
+
+typedef AcademicCalendarHttpGet = Future<http.Response> Function(Uri uri);
+typedef AcademicCalendarDataLoader = Future<AcademicCalendarData> Function();
 
 class AcademicCalendarPage extends StatefulWidget {
-  const AcademicCalendarPage({super.key});
+  const AcademicCalendarPage({
+    super.key,
+    this.httpGet,
+    this.interactiveDataLoader,
+  });
+
+  final AcademicCalendarHttpGet? httpGet;
+  final AcademicCalendarDataLoader? interactiveDataLoader;
 
   @override
   State<AcademicCalendarPage> createState() => _AcademicCalendarPageState();
@@ -61,15 +72,18 @@ class _AcademicCalendarPageState extends State<AcademicCalendarPage>
 
   // Fetch official calendar list (images)
   Future<void> _loadList() async {
+    if (!mounted) return;
     setState(() {
       _loading = true;
       _error = null;
     });
 
     try {
-      final resp = await http
-          .get(Uri.parse('$_base/cdxl.htm'))
-          .timeout(const Duration(seconds: 8));
+      final request =
+          widget.httpGet?.call(Uri.parse('$_base/cdxl.htm')) ??
+          http.get(Uri.parse('$_base/cdxl.htm'));
+      final resp = await request.timeout(const Duration(seconds: 8));
+      if (!mounted) return;
       if (resp.statusCode != 200) {
         throw Exception('HTTP ${resp.statusCode}');
       }
@@ -92,6 +106,7 @@ class _AcademicCalendarPageState extends State<AcademicCalendarPage>
         throw Exception('No calendar entries found');
       }
 
+      if (!mounted) return;
       setState(() {
         _entries = entries;
         _selected = entries.first;
@@ -109,6 +124,7 @@ class _AcademicCalendarPageState extends State<AcademicCalendarPage>
   }
 
   Future<void> _loadDetail(CalendarEntry entry) async {
+    if (!mounted) return;
     setState(() {
       _loading = true;
       _error = null;
@@ -116,9 +132,10 @@ class _AcademicCalendarPageState extends State<AcademicCalendarPage>
     });
 
     try {
-      final resp = await http
-          .get(Uri.parse('$_base/${entry.path}'))
-          .timeout(const Duration(seconds: 8));
+      final uri = Uri.parse('$_base/${entry.path}');
+      final request = widget.httpGet?.call(uri) ?? http.get(uri);
+      final resp = await request.timeout(const Duration(seconds: 8));
+      if (!mounted) return;
       if (resp.statusCode != 200) {
         throw Exception('HTTP ${resp.statusCode}');
       }
@@ -155,14 +172,18 @@ class _AcademicCalendarPageState extends State<AcademicCalendarPage>
 
   // Fetch interactive calendar data
   Future<void> _loadInteractiveData() async {
+    if (!mounted) return;
     setState(() {
       _interactiveLoading = true;
       _interactiveError = null;
     });
 
     try {
-      final service = getIt<AcademicCalendarService>();
-      final data = await service.fetchCalendarData();
+      final loader = widget.interactiveDataLoader;
+      final data = loader != null
+          ? await loader()
+          : await getIt<AcademicCalendarService>().fetchCalendarData();
+      if (!mounted) return;
 
       AcademicCalendarSemester? initialSemester;
       final now = DateTime.now();

--- a/lib/pages/campus/academic_calendar/official_calendar_view.dart
+++ b/lib/pages/campus/academic_calendar/official_calendar_view.dart
@@ -4,6 +4,9 @@ import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/widgets/common/retryable_error_widget.dart';
 import 'package:bugaoshan/widgets/common/image_viewer.dart';
 
+typedef OfficialCalendarImageBuilder =
+    Widget Function(BuildContext context, String url);
+
 class CalendarEntry {
   final String title;
   final String path;
@@ -17,6 +20,7 @@ class OfficialCalendarView extends StatelessWidget {
   final bool loading;
   final String? error;
   final List<String> imageUrls;
+  final OfficialCalendarImageBuilder? imageBuilder;
   final ValueChanged<CalendarEntry> onEntryChanged;
   final VoidCallback onRetry;
 
@@ -27,6 +31,7 @@ class OfficialCalendarView extends StatelessWidget {
     required this.loading,
     this.error,
     required this.imageUrls,
+    this.imageBuilder,
     required this.onEntryChanged,
     required this.onRetry,
   });
@@ -86,58 +91,62 @@ class OfficialCalendarView extends StatelessWidget {
       padding: const EdgeInsets.fromLTRB(16, 16, 16, 32),
       itemCount: imageUrls.length,
       itemBuilder: (context, index) {
+        final imageUrl = imageUrls[index];
         return Padding(
           padding: EdgeInsets.only(
             bottom: index < imageUrls.length - 1 ? 12 : 0,
           ),
           child: GestureDetector(
-            onTap: () =>
-                showFullScreenImageViewer(context, imageUrl: imageUrls[index]),
+            onTap: () => showFullScreenImageViewer(context, imageUrl: imageUrl),
             child: ClipRRect(
               borderRadius: BorderRadius.circular(AppShapes.medium),
-              child: Image.network(
-                imageUrls[index],
-                fit: BoxFit.fitWidth,
-                loadingBuilder: (context, child, progress) {
-                  if (progress == null) return child;
-                  return Container(
-                    height: 200,
-                    alignment: Alignment.center,
-                    child: CircularProgressIndicator(
-                      value: progress.expectedTotalBytes != null
-                          ? progress.cumulativeBytesLoaded /
-                                progress.expectedTotalBytes!
-                          : null,
-                    ),
-                  );
-                },
-                errorBuilder: (context, error, stackTrace) {
-                  return Container(
-                    height: 200,
-                    alignment: Alignment.center,
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Icon(
-                          Icons.broken_image,
-                          size: 48,
-                          color: Theme.of(context).colorScheme.onSurfaceVariant,
+              child:
+                  imageBuilder?.call(context, imageUrl) ??
+                  Image.network(
+                    imageUrl,
+                    fit: BoxFit.fitWidth,
+                    loadingBuilder: (context, child, progress) {
+                      if (progress == null) return child;
+                      return Container(
+                        height: 200,
+                        alignment: Alignment.center,
+                        child: CircularProgressIndicator(
+                          value: progress.expectedTotalBytes != null
+                              ? progress.cumulativeBytesLoaded /
+                                    progress.expectedTotalBytes!
+                              : null,
                         ),
-                        const SizedBox(height: 8),
-                        Text(
-                          l10n.loadFailed,
-                          style: Theme.of(context).textTheme.bodyMedium
-                              ?.copyWith(
-                                color: Theme.of(
-                                  context,
-                                ).colorScheme.onSurfaceVariant,
-                              ),
+                      );
+                    },
+                    errorBuilder: (context, error, stackTrace) {
+                      return Container(
+                        height: 200,
+                        alignment: Alignment.center,
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Icon(
+                              Icons.broken_image,
+                              size: 48,
+                              color: Theme.of(
+                                context,
+                              ).colorScheme.onSurfaceVariant,
+                            ),
+                            const SizedBox(height: 8),
+                            Text(
+                              l10n.loadFailed,
+                              style: Theme.of(context).textTheme.bodyMedium
+                                  ?.copyWith(
+                                    color: Theme.of(
+                                      context,
+                                    ).colorScheme.onSurfaceVariant,
+                                  ),
+                            ),
+                          ],
                         ),
-                      ],
-                    ),
-                  );
-                },
-              ),
+                      );
+                    },
+                  ),
             ),
           ),
         );

--- a/lib/pages/campus/class_schedule_inquiry/class_schedule_inquiry_detail_page.dart
+++ b/lib/pages/campus/class_schedule_inquiry/class_schedule_inquiry_detail_page.dart
@@ -117,9 +117,8 @@ class _ClassScheduleInquiryDetailPageState
     const int totalPeriods = 12;
     final gridHeight = headerHeight + totalPeriods * rowHeight;
 
-    // showAllWeeks 模式不读取 semesterStartDate，设任意值即可
-    // 显示设置（showTeacherName/showLocation/showWeekend）已迁移到 AppConfigProvider
-    getIt<AppConfigProvider>().showWeekend.value = hasWeekend;
+    // showAllWeeks 模式不读取 semesterStartDate，设任意值即可。
+    // 班级详情只在当前网格局部决定是否显示周末，不能改写用户主课表偏好。
     final gridConfig = ScheduleConfig(
       semesterStartDate: DateTime(2025, 9, 1),
       morningSections: 0,
@@ -152,6 +151,7 @@ class _ClassScheduleInquiryDetailPageState
               config: gridConfig,
               displayWeek: 1,
               showAllWeeks: true,
+              showWeekendOverride: hasWeekend,
             ),
           ),
         ],

--- a/lib/pages/campus/downloads/attachments_sheet.dart
+++ b/lib/pages/campus/downloads/attachments_sheet.dart
@@ -26,7 +26,7 @@ void showAttachmentsSheet(
   // Prime the manager: enqueue tasks for items that already exist on disk,
   // and revoke stale tasks whose files have been deleted.
   for (final item in items) {
-    checkDownloadedFile(dirName, item.name).then((path) {
+    checkDownloadedFile(dirName, item.name, url: item.url).then((path) {
       if (path != null) {
         final task = manager.enqueue(
           item.url,
@@ -42,9 +42,9 @@ void showAttachmentsSheet(
           );
         }
       } else {
-        final existing = manager.taskFor(dirName, item.name);
+        final existing = manager.taskFor(item.url, dirName);
         if (existing != null && existing.status == DownloadStatus.done) {
-          manager.remove(dirName, item.name);
+          manager.remove(item.url, dirName);
         }
       }
     });
@@ -186,7 +186,7 @@ class _SheetAttachmentTile extends StatelessWidget {
     return ListenableBuilder(
       listenable: manager,
       builder: (context, _) {
-        final task = manager.taskFor(dirName, item.name);
+        final task = manager.taskFor(item.url, dirName);
 
         // Show done state if task completed or file already known.
         if (task != null &&
@@ -257,7 +257,7 @@ class _SheetAttachmentTile extends StatelessWidget {
       leading: Icon(_fileIcon(), color: Theme.of(context).colorScheme.primary),
       title: Text(item.name, maxLines: 2, overflow: TextOverflow.ellipsis),
       trailing: FutureBuilder<String?>(
-        future: checkDownloadedFile(dirName, item.name),
+        future: checkDownloadedFile(dirName, item.name, url: item.url),
         builder: (context, snapshot) {
           if (snapshot.connectionState != ConnectionState.done) {
             return const SizedBox(

--- a/lib/pages/campus/downloads/attachments_sheet.dart
+++ b/lib/pages/campus/downloads/attachments_sheet.dart
@@ -161,7 +161,8 @@ class _SheetAttachmentTile extends StatelessWidget {
   }
 
   void _open(String path) => OpenFilex.open(path);
-  void _share(String path) => shareSingleFile(path);
+  void _share(BuildContext context, String path) =>
+      shareSingleFile(path, context: context);
 
   Future<void> _startDownload(DownloadManager manager) async {
     if (onWebViewDownload != null) {
@@ -280,7 +281,7 @@ class _SheetAttachmentTile extends StatelessWidget {
                 downloadedPath: snapshot.data,
               );
             }
-            return _doneTrailing(snapshot.data!);
+            return _doneTrailing(context, snapshot.data!);
           }
           return IconButton(
             icon: const Icon(Icons.download),
@@ -296,18 +297,18 @@ class _SheetAttachmentTile extends StatelessWidget {
     return ListTile(
       leading: Icon(_fileIcon(), color: Theme.of(context).colorScheme.primary),
       title: Text(item.name, maxLines: 2, overflow: TextOverflow.ellipsis),
-      trailing: _doneTrailing(path),
+      trailing: _doneTrailing(context, path),
     );
   }
 
-  Widget _doneTrailing(String path) {
+  Widget _doneTrailing(BuildContext context, String path) {
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
         IconButton(
           icon: const Icon(Icons.share),
           tooltip: '分享',
-          onPressed: () => _share(path),
+          onPressed: () => _share(context, path),
         ),
         IconButton(
           icon: const Icon(Icons.check_circle, color: Colors.green),

--- a/lib/pages/campus/downloads/file_utils.dart
+++ b/lib/pages/campus/downloads/file_utils.dart
@@ -1,5 +1,8 @@
+import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
+import 'package:crypto/crypto.dart';
 import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
@@ -17,6 +20,158 @@ const kTuanweiAttachmentDir = 'tuanwei_attachments';
 
 /// Subdirectory name under `Bugaoshan/` for saved auth log exports.
 const kAuthLogDir = 'auth_logs';
+
+/// Persistent URL-to-file index for notice attachments.
+///
+/// One metadata file is stored per URL so concurrent downloads do not overwrite
+/// a shared JSON map. Legacy files are adopted only when no other URL already
+/// owns that path.
+class DownloadPathIndex {
+  DownloadPathIndex(this.downloadDir);
+
+  static const _indexDirName = '.download_index';
+  static final Map<String, Future<void>> _directoryQueues = {};
+
+  final Directory downloadDir;
+
+  Directory get _indexDir => Directory(p.join(downloadDir.path, _indexDirName));
+
+  String get _queueKey => p.normalize(downloadDir.absolute.path);
+
+  File _entryFor(String url) {
+    final key = sha256.convert(utf8.encode(url)).toString();
+    return File(p.join(_indexDir.path, '$key.json'));
+  }
+
+  Future<T> _synchronized<T>(Future<T> Function() action) async {
+    final previous = _directoryQueues[_queueKey] ?? Future<void>.value();
+    final gate = Completer<void>();
+    final current = gate.future;
+    _directoryQueues[_queueKey] = current;
+    try {
+      try {
+        await previous;
+      } catch (_) {
+        // A previous operation must not poison the per-directory queue.
+      }
+      return await action();
+    } finally {
+      gate.complete();
+      if (identical(_directoryQueues[_queueKey], current)) {
+        _directoryQueues.remove(_queueKey);
+      }
+    }
+  }
+
+  Future<void> record(String url, String path) {
+    return _synchronized(() => _recordUnlocked(url, path));
+  }
+
+  Future<void> _recordUnlocked(String url, String path) async {
+    final fileName = p.basename(path);
+    final expectedPath = p.normalize(p.join(downloadDir.path, fileName));
+    if (p.normalize(path) != expectedPath) {
+      throw ArgumentError.value(path, 'path', 'must be inside downloadDir');
+    }
+
+    await _indexDir.create(recursive: true);
+    final entry = _entryFor(url);
+    final temporary = File('${entry.path}.tmp');
+    await temporary.writeAsString(
+      jsonEncode({'version': 1, 'fileName': fileName}),
+      flush: true,
+    );
+    if (await entry.exists()) await entry.delete();
+    await temporary.rename(entry.path);
+  }
+
+  Future<String?> resolve(String url, {required String legacyFileName}) {
+    return _synchronized(() async {
+      final mapped = await _mappedPath(url);
+      if (mapped != null) return mapped;
+
+      final claimed = await _claimedFileNames();
+      for (final candidate in _legacyCandidates(legacyFileName)) {
+        final fileName = p.basename(candidate);
+        if (claimed.contains(fileName)) continue;
+        if (!await File(candidate).exists()) continue;
+        await _recordUnlocked(url, candidate);
+        return candidate;
+      }
+      return null;
+    });
+  }
+
+  Future<void> removePath(String path) {
+    return _synchronized(() async {
+      if (!await _indexDir.exists()) return;
+      final targetName = p.basename(path);
+      await for (final entry in _indexDir.list().where(
+        (entry) => entry is File && entry.path.endsWith('.json'),
+      )) {
+        final file = entry as File;
+        final fileName = await _readFileName(file);
+        if (fileName == targetName && await file.exists()) {
+          await file.delete();
+        }
+      }
+    });
+  }
+
+  Future<String?> _mappedPath(String url) async {
+    final entry = _entryFor(url);
+    if (!await entry.exists()) return null;
+    final fileName = await _readFileName(entry);
+    if (fileName == null) return null;
+    final path = p.join(downloadDir.path, fileName);
+    if (await File(path).exists()) return path;
+    if (await entry.exists()) await entry.delete();
+    return null;
+  }
+
+  Future<Set<String>> _claimedFileNames() async {
+    if (!await _indexDir.exists()) return {};
+    final claimed = <String>{};
+    await for (final entry in _indexDir.list().where(
+      (entry) => entry is File && entry.path.endsWith('.json'),
+    )) {
+      final file = entry as File;
+      final fileName = await _readFileName(file);
+      if (fileName == null) continue;
+      if (await File(p.join(downloadDir.path, fileName)).exists()) {
+        claimed.add(fileName);
+      } else if (await file.exists()) {
+        await file.delete();
+      }
+    }
+    return claimed;
+  }
+
+  Future<String?> _readFileName(File entry) async {
+    try {
+      final data = jsonDecode(await entry.readAsString());
+      if (data is! Map<String, dynamic>) throw const FormatException();
+      final rawName = data['fileName'];
+      if (rawName is! String || rawName != p.basename(rawName)) {
+        throw const FormatException();
+      }
+      return rawName;
+    } catch (_) {
+      if (await entry.exists()) await entry.delete();
+      return null;
+    }
+  }
+
+  Iterable<String> _legacyCandidates(String rawName) sync* {
+    final safeName = sanitizeDownloadFileName(rawName);
+    yield p.join(downloadDir.path, safeName);
+    final baseName = p.basenameWithoutExtension(safeName);
+    final extension = p.extension(safeName);
+    for (var i = 1; i <= 99; i++) {
+      yield p.join(downloadDir.path, '$baseName ($i)$extension');
+    }
+  }
+}
 
 // ── File utilities ─────────────────────────────────────────────────────────────────
 
@@ -140,14 +295,23 @@ Future<String> downloadFile(
   }
 
   await file.writeAsBytes(bytes);
+  await DownloadPathIndex(saveDir).record(url, filePath);
   return filePath;
 }
 
 /// Returns the path of an already-downloaded file, or null.
-Future<String?> checkDownloadedFile(String dirName, String fileName) async {
+Future<String?> checkDownloadedFile(
+  String dirName,
+  String fileName, {
+  String? url,
+}) async {
   final base = await getNoticeBaseDir();
   final saveDir = Directory('${base.path}/Bugaoshan/$dirName');
   if (!await saveDir.exists()) return null;
+
+  if (url != null) {
+    return DownloadPathIndex(saveDir).resolve(url, legacyFileName: fileName);
+  }
 
   final safeFileName = sanitizeDownloadFileName(fileName);
   final exactPath = '${saveDir.path}/$safeFileName';
@@ -160,4 +324,11 @@ Future<String?> checkDownloadedFile(String dirName, String fileName) async {
     if (await File(variantPath).exists()) return variantPath;
   }
   return null;
+}
+
+Future<void> removeDownloadPathMapping(String dirName, String path) async {
+  final base = await getNoticeBaseDir();
+  final saveDir = Directory('${base.path}/Bugaoshan/$dirName');
+  if (!await saveDir.exists()) return;
+  await DownloadPathIndex(saveDir).removePath(path);
 }

--- a/lib/pages/campus/downloads/notice_downloaded_page.dart
+++ b/lib/pages/campus/downloads/notice_downloaded_page.dart
@@ -304,11 +304,11 @@ class _NoticeDownloadedPageState extends State<NoticeDownloadedPage>
       if (await file.exists()) await file.delete();
       // Remove stale task from DownloadManager so the attachment sheet
       // won't show a deleted file as "already downloaded".
-      final fileName = p.basename(path);
       for (final cfg in _dirConfigs) {
         if (path.contains('/${cfg.dirName}/') ||
             path.contains('\\${cfg.dirName}\\')) {
-          manager.remove(cfg.dirName, fileName);
+          manager.removeByDownloadedPath(path);
+          await removeDownloadPathMapping(cfg.dirName, path);
           break;
         }
       }

--- a/lib/pages/campus/downloads/notice_downloaded_page.dart
+++ b/lib/pages/campus/downloads/notice_downloaded_page.dart
@@ -367,9 +367,10 @@ class _NoticeDownloadedPageState extends State<NoticeDownloadedPage>
 
   void _openFile(File file) => OpenFilex.open(file.path);
 
-  void _shareFile(File file) => shareSingleFile(file.path);
+  void _shareFile(File file) => shareSingleFile(file.path, context: context);
 
-  void _shareSelected() => shareMultipleFiles(_selected.toList());
+  void _shareSelected() =>
+      shareMultipleFiles(_selected.toList(), context: context);
 
   void _showFilterMenu() {
     final l10n = AppLocalizations.of(context)!;

--- a/lib/pages/course/import_schedule_page.dart
+++ b/lib/pages/course/import_schedule_page.dart
@@ -8,6 +8,7 @@ import 'package:bugaoshan/providers/course_provider.dart';
 import 'package:bugaoshan/providers/scu_auth_provider.dart';
 import 'package:bugaoshan/services/api/zhjw_api_service.dart';
 import 'package:bugaoshan/services/auth/scu_exceptions.dart';
+import 'package:bugaoshan/utils/class_week_parser.dart';
 import 'package:bugaoshan/widgets/dialog/dialog.dart';
 import 'package:bugaoshan/widgets/route/router_utils.dart';
 
@@ -553,45 +554,25 @@ class _ImportSchedulePageState extends State<ImportSchedulePage> {
               '${tpMap['teachingBuildingName'] ?? ''}${tpMap['classroomName'] ?? ''}';
           final String classWeek = tpMap['classWeek'] as String? ?? '';
 
-          // Parse weeks from classWeek bitstring (e.g. "111111111111111100000000")
-          int startWeek = -1;
-          int endWeek = -1;
-          List<int> activeWeeks = [];
-          for (int i = 0; i < classWeek.length; i++) {
-            if (classWeek[i] == '1') {
-              int w = i + 1;
-              if (startWeek == -1) startWeek = w;
-              endWeek = w;
-              activeWeeks.add(w);
+          final weekSegments = parseClassWeekSegments(classWeek);
+          if (weekSegments.isNotEmpty) {
+            final colorValue = colors[colorIdx % colors.length].toARGB32();
+            for (final segment in weekSegments) {
+              courses.add(
+                Course(
+                  name: courseName,
+                  teacher: teacher,
+                  location: location,
+                  startWeek: segment.startWeek,
+                  endWeek: segment.endWeek,
+                  dayOfWeek: dayOfWeek,
+                  startSection: startSection,
+                  endSection: endSection,
+                  colorValue: colorValue,
+                  weekType: segment.weekType,
+                ),
+              );
             }
-          }
-
-          if (startWeek != -1) {
-            WeekType weekType = WeekType.every;
-            if (activeWeeks.length > 1) {
-              bool allOdd = activeWeeks.every((w) => w % 2 != 0);
-              bool allEven = activeWeeks.every((w) => w % 2 == 0);
-              if (allOdd) {
-                weekType = WeekType.odd;
-              } else if (allEven) {
-                weekType = WeekType.even;
-              }
-            }
-
-            courses.add(
-              Course(
-                name: courseName,
-                teacher: teacher,
-                location: location,
-                startWeek: startWeek,
-                endWeek: endWeek,
-                dayOfWeek: dayOfWeek,
-                startSection: startSection,
-                endSection: endSection,
-                colorValue: colors[colorIdx % colors.length].toARGB32(),
-                weekType: weekType,
-              ),
-            );
             colorIdx++;
           }
         }

--- a/lib/pages/dev/auth_log/auth_log_viewer_page.dart
+++ b/lib/pages/dev/auth_log/auth_log_viewer_page.dart
@@ -167,7 +167,8 @@ class _AuthLogViewerPageState extends State<AuthLogViewerPage> {
       final dir = await _authLogDir();
       final path = await _log.exportToFile(dir);
       try {
-        await shareSingleFile(path);
+        if (!mounted) return;
+        await shareSingleFile(path, context: context);
         messenger.showSnackBar(const SnackBar(content: Text('Saved')));
       } catch (e) {
         messenger.showSnackBar(SnackBar(content: Text('Save failed: $e')));

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -14,6 +14,7 @@ import 'package:bugaoshan/services/auth/auth_coordinator.dart';
 import 'package:bugaoshan/services/update_service.dart';
 import 'package:bugaoshan/services/widget_update_service.dart';
 import 'package:bugaoshan/utils/constants.dart';
+import 'package:bugaoshan/widgets/common/auth_scoped_indexed_stack.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({super.key});
@@ -25,24 +26,6 @@ class HomePage extends StatefulWidget {
 class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
   int _currentIndex = 0;
   final _courseProvider = getIt<CourseProvider>();
-  final Map<String, Widget> _pageCache = {};
-
-  /// Lazily builds and returns an [IndexedStack] of all visited pages.
-  /// Only the page at [selectedIndex] is visible; others are kept alive.
-  Widget _buildIndexedStack(List<String> visibleIds, int selectedIndex) {
-    for (final id in visibleIds) {
-      _pageCache.putIfAbsent(id, () => campusItemConfigById(id).page());
-    }
-    // Clean up pages no longer visible
-    _pageCache.keys
-        .where((id) => !visibleIds.contains(id))
-        .toList()
-        .forEach(_pageCache.remove);
-    return IndexedStack(
-      index: selectedIndex.clamp(0, visibleIds.length - 1),
-      children: visibleIds.map((id) => _pageCache[id]!).toList(),
-    );
-  }
 
   @override
   void initState() {
@@ -117,6 +100,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
 
   Widget _buildMainScreen() {
     final appConfig = getIt<AppConfigProvider>();
+    final authProvider = getIt<ScuAuthProvider>();
     final l10n = AppLocalizations.of(context)!;
 
     return ValueListenableBuilder<List<String>>(
@@ -132,9 +116,12 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver {
                 final isWide = constraints.maxWidth >= 600;
                 final showRail = isWide && visibleIds.length >= 2;
                 final showBar = !isWide && visibleIds.length >= 2;
-                final pageContent = _buildIndexedStack(
-                  visibleIds,
-                  _currentIndex,
+                final pageContent = AuthScopedIndexedStack(
+                  authListenable: authProvider,
+                  isAuthenticated: () => authProvider.isLoggedIn,
+                  visibleIds: visibleIds,
+                  selectedIndex: _currentIndex,
+                  pageBuilder: (id) => campusItemConfigById(id).page(),
                 );
                 return Scaffold(
                   body: Row(

--- a/lib/pages/settings/set_app_icon_page.dart
+++ b/lib/pages/settings/set_app_icon_page.dart
@@ -24,13 +24,16 @@ class _SetAppIconPageState extends State<SetAppIconPage> {
   Future<void> _loadData() async {
     try {
       final icons = await DynamicIconService.getAvailableIcons();
+      if (!mounted) return;
       final current = await DynamicIconService.getCurrentIconName();
+      if (!mounted) return;
       setState(() {
         _availableIcons = icons;
         _currentIcon = current;
         _isLoading = false;
       });
     } catch (_) {
+      if (!mounted) return;
       setState(() => _isLoading = false);
     }
   }

--- a/lib/providers/balance_query_provider.dart
+++ b/lib/providers/balance_query_provider.dart
@@ -70,9 +70,13 @@ class BalanceQueryProvider extends ChangeNotifier {
   Future<void> removeBinding(int index) async {
     if (index < 0 || index >= _bindings.length) return;
     _bindings.removeAt(index);
-    if (_currentIndex >= _bindings.length) {
+    if (index < _currentIndex) {
+      _currentIndex--;
+    } else if (_currentIndex >= _bindings.length) {
       _currentIndex = _bindings.isEmpty ? 0 : _bindings.length - 1;
     }
+    _electricInfo = null;
+    _acInfo = null;
     await _saveBindingInfo();
     notifyListeners();
   }

--- a/lib/providers/grades_provider.dart
+++ b/lib/providers/grades_provider.dart
@@ -14,9 +14,36 @@ enum GradesLoadState { idle, loading, loaded, error }
 class GradesProvider extends ChangeNotifier {
   final SharedPreferences _prefs;
   final ZhjwApiService _zhjwApi;
+  String? _userIdentity;
+  int _identityGeneration = 0;
 
-  GradesProvider(this._prefs, this._zhjwApi) {
-    final cachedScheme = _prefs.getString(_keySchemeScores);
+  GradesProvider(this._prefs, this._zhjwApi, {String? initialUserId})
+    : _userIdentity = _normalizeIdentity(initialUserId) {
+    _restoreCache();
+  }
+
+  static String? _normalizeIdentity(String? value) {
+    final normalized = value?.trim();
+    return normalized == null || normalized.isEmpty ? null : normalized;
+  }
+
+  String _userCacheKey(String baseKey, String userIdentity) =>
+      '${baseKey}_$userIdentity';
+
+  void _restoreCache() {
+    _schemeScores = null;
+    _schemeState = GradesLoadState.idle;
+    _schemeError = null;
+    _passingScores = null;
+    _passingState = GradesLoadState.idle;
+    _passingError = null;
+
+    final userIdentity = _userIdentity;
+    if (userIdentity == null) return;
+
+    final cachedScheme = _prefs.getString(
+      _userCacheKey(_keySchemeScores, userIdentity),
+    );
     if (cachedScheme != null) {
       try {
         _schemeScores = SchemeScoreSummary.fromJson(
@@ -25,7 +52,9 @@ class GradesProvider extends ChangeNotifier {
         _schemeState = GradesLoadState.loaded;
       } catch (_) {}
     }
-    final cachedPassing = _prefs.getString(_keyPassingScores);
+    final cachedPassing = _prefs.getString(
+      _userCacheKey(_keyPassingScores, userIdentity),
+    );
     if (cachedPassing != null) {
       try {
         _passingScores = PassingScoreResult.fromJson(
@@ -34,6 +63,16 @@ class GradesProvider extends ChangeNotifier {
         _passingState = GradesLoadState.loaded;
       } catch (_) {}
     }
+  }
+
+  /// 切换已确认的 SCU 身份；身份未知时不恢复任何持久化成绩。
+  void setUserIdentity(String? userId) {
+    final normalized = _normalizeIdentity(userId);
+    if (normalized == _userIdentity) return;
+    _identityGeneration++;
+    _userIdentity = normalized;
+    _restoreCache();
+    notifyListeners();
   }
 
   // --- 方案成绩 ---
@@ -47,15 +86,25 @@ class GradesProvider extends ChangeNotifier {
 
   Future<void> refreshSchemeScores() async {
     if (_schemeState == GradesLoadState.loading) return;
+    final generation = _identityGeneration;
+    final userIdentity = _userIdentity;
     _schemeState = GradesLoadState.loading;
     _schemeError = null;
     notifyListeners();
     try {
       final data = await _zhjwApi.fetchSchemeScores();
+      if (generation != _identityGeneration) return;
       _schemeScores = SchemeScoreSummary.fromJson(data);
       _schemeState = GradesLoadState.loaded;
-      await _prefs.setString(_keySchemeScores, jsonEncode(data));
+      if (userIdentity != null) {
+        await _prefs.setString(
+          _userCacheKey(_keySchemeScores, userIdentity),
+          jsonEncode(data),
+        );
+        if (generation != _identityGeneration) return;
+      }
     } on UnauthenticatedException {
+      if (generation != _identityGeneration) return;
       if (_schemeScores != null) {
         _schemeState = GradesLoadState.loaded;
         _schemeError = LoadErrorType.sessionExpired;
@@ -64,6 +113,7 @@ class GradesProvider extends ChangeNotifier {
         _schemeError = LoadErrorType.sessionExpired;
       }
     } catch (e) {
+      if (generation != _identityGeneration) return;
       debugPrint('Scheme scores load error: $e');
       if (_schemeScores != null) {
         _schemeState = GradesLoadState.loaded;
@@ -91,15 +141,25 @@ class GradesProvider extends ChangeNotifier {
 
   Future<void> refreshPassingScores() async {
     if (_passingState == GradesLoadState.loading) return;
+    final generation = _identityGeneration;
+    final userIdentity = _userIdentity;
     _passingState = GradesLoadState.loading;
     _passingError = null;
     notifyListeners();
     try {
       final data = await _zhjwApi.fetchPassingScores();
+      if (generation != _identityGeneration) return;
       _passingScores = PassingScoreResult.fromJson(data);
       _passingState = GradesLoadState.loaded;
-      await _prefs.setString(_keyPassingScores, jsonEncode(data));
+      if (userIdentity != null) {
+        await _prefs.setString(
+          _userCacheKey(_keyPassingScores, userIdentity),
+          jsonEncode(data),
+        );
+        if (generation != _identityGeneration) return;
+      }
     } on UnauthenticatedException {
+      if (generation != _identityGeneration) return;
       if (_passingScores != null) {
         _passingState = GradesLoadState.loaded;
         _passingError = LoadErrorType.sessionExpired;
@@ -108,6 +168,7 @@ class GradesProvider extends ChangeNotifier {
         _passingError = LoadErrorType.sessionExpired;
       }
     } catch (e) {
+      if (generation != _identityGeneration) return;
       debugPrint('Passing scores load error: $e');
       if (_passingScores != null) {
         _passingState = GradesLoadState.loaded;

--- a/lib/providers/grades_provider.dart
+++ b/lib/providers/grades_provider.dart
@@ -27,6 +27,12 @@ class GradesProvider extends ChangeNotifier {
     return normalized == null || normalized.isEmpty ? null : normalized;
   }
 
+  /// 仅接受与当前 token 绑定的 SCU principal 作为成绩缓存身份。
+  static String? confirmedUserIdentity({
+    required bool isLoggedIn,
+    required String? principal,
+  }) => isLoggedIn ? _normalizeIdentity(principal) : null;
+
   String _userCacheKey(String baseKey, String userIdentity) =>
       '${baseKey}_$userIdentity';
 

--- a/lib/providers/plan_completion_provider.dart
+++ b/lib/providers/plan_completion_provider.dart
@@ -14,6 +14,7 @@ enum PlanCompletionLoadState { idle, loading, loaded, error }
 class PlanCompletionProvider extends ChangeNotifier {
   final SharedPreferences _prefs;
   final ZhjwApiService _zhjwApi;
+  int _requestGeneration = 0;
 
   PlanCompletionProvider(this._prefs, this._zhjwApi) {
     final cached = _prefs.getString(_keyPlanCompletion);
@@ -51,17 +52,22 @@ class PlanCompletionProvider extends ChangeNotifier {
 
     // Use cache if already loaded and not forcing refresh
     if (!forceRefresh && _state == PlanCompletionLoadState.loaded) return;
+    final generation = ++_requestGeneration;
 
     _state = PlanCompletionLoadState.loading;
     _error = null;
     _safeNotify();
 
     try {
-      _nodes = await _zhjwApi.fetchPlanCompletion();
+      final nodes = await _zhjwApi.fetchPlanCompletion();
+      if (generation != _requestGeneration) return;
+      _nodes = nodes;
       _state = PlanCompletionLoadState.loaded;
       _error = null;
       await _saveToCache();
+      if (generation != _requestGeneration) return;
     } on RateLimitedException catch (_) {
+      if (generation != _requestGeneration) return;
       if (_nodes.isNotEmpty) {
         _state = PlanCompletionLoadState.loaded;
       } else {
@@ -69,6 +75,7 @@ class PlanCompletionProvider extends ChangeNotifier {
       }
       _error = LoadErrorType.rateLimited;
     } on ServiceException catch (_) {
+      if (generation != _requestGeneration) return;
       if (_nodes.isNotEmpty) {
         _state = PlanCompletionLoadState.loaded;
         _error = campusNetworkErrorType(LoadErrorType.loadFailed);
@@ -77,6 +84,7 @@ class PlanCompletionProvider extends ChangeNotifier {
         _error = campusNetworkErrorType(LoadErrorType.loadFailed);
       }
     } on UnauthenticatedException {
+      if (generation != _requestGeneration) return;
       if (_nodes.isNotEmpty) {
         _state = PlanCompletionLoadState.loaded;
       } else {
@@ -84,6 +92,7 @@ class PlanCompletionProvider extends ChangeNotifier {
       }
       _error = LoadErrorType.sessionExpired;
     } catch (_) {
+      if (generation != _requestGeneration) return;
       if (_nodes.isNotEmpty) {
         _state = PlanCompletionLoadState.loaded;
       } else {
@@ -111,9 +120,11 @@ class PlanCompletionProvider extends ChangeNotifier {
   };
 
   Future<void> clearCache() async {
+    _requestGeneration++;
     _nodes = [];
     _state = PlanCompletionLoadState.idle;
     _error = null;
+    _safeNotify();
     await _prefs.remove(_keyPlanCompletion);
   }
 }

--- a/lib/providers/scu_auth_provider.dart
+++ b/lib/providers/scu_auth_provider.dart
@@ -74,7 +74,7 @@ class ScuAuthProvider extends ChangeNotifier {
     required String captchaCode,
     required String captchaText,
   }) async {
-    _log.i(_tag, 'login: start user=$username');
+    _log.i(_tag, 'login: start');
     await _scuAuth.login(
       username: username,
       password: password,
@@ -141,7 +141,7 @@ class ScuAuthProvider extends ChangeNotifier {
     final username = credentials['username']!;
     final password = credentials['password']!;
 
-    _log.i(_tag, 'autoLogin: starting user=$username');
+    _log.i(_tag, 'autoLogin: starting');
     _isAutoLoggingIn = true;
     notifyListeners();
 

--- a/lib/providers/train_program_provider.dart
+++ b/lib/providers/train_program_provider.dart
@@ -32,6 +32,8 @@ class TrainProgramProvider extends ChangeNotifier {
 
   String? _selectedCollege;
   String? _selectedGrade;
+  int _detailGeneration = 0;
+  int _courseDetailGeneration = 0;
 
   List<College> get colleges => _colleges;
   List<Grade> get grades => _grades;
@@ -135,21 +137,26 @@ class TrainProgramProvider extends ChangeNotifier {
   }
 
   Future<void> fetchProgramDetail(String fajhh) async {
-    if (_detailState == TrainProgramLoadState.loading) return;
+    final generation = ++_detailGeneration;
     _detailState = TrainProgramLoadState.loading;
     _detailError = null;
     _safeNotify();
 
     try {
-      _currentDetail = await _zhjwApi.fetchProgramDetail(fajhh);
+      final detail = await _zhjwApi.fetchProgramDetail(fajhh);
+      if (generation != _detailGeneration) return;
+      _currentDetail = detail;
       _detailState = TrainProgramLoadState.loaded;
     } on UnauthenticatedException {
+      if (generation != _detailGeneration) return;
       _detailState = TrainProgramLoadState.error;
       _detailError = LoadErrorType.sessionExpired;
     } on ServiceException catch (_) {
+      if (generation != _detailGeneration) return;
       _detailState = TrainProgramLoadState.error;
       _detailError = campusNetworkErrorType(LoadErrorType.loadFailed);
     } catch (_) {
+      if (generation != _detailGeneration) return;
       _detailState = TrainProgramLoadState.error;
       _detailError = campusNetworkErrorType(LoadErrorType.loadFailed);
     }
@@ -157,27 +164,34 @@ class TrainProgramProvider extends ChangeNotifier {
   }
 
   void clearDetail() {
+    _detailGeneration++;
     _currentDetail = null;
     _detailState = TrainProgramLoadState.idle;
+    _detailError = null;
     _safeNotify();
   }
 
   Future<void> fetchCourseDetail(String urlPath) async {
-    if (_courseDetailState == TrainProgramLoadState.loading) return;
+    final generation = ++_courseDetailGeneration;
     _courseDetailState = TrainProgramLoadState.loading;
     _courseDetailError = null;
     _safeNotify();
 
     try {
-      _currentCourseDetail = await _zhjwApi.fetchCourseDetail(urlPath);
+      final detail = await _zhjwApi.fetchCourseDetail(urlPath);
+      if (generation != _courseDetailGeneration) return;
+      _currentCourseDetail = detail;
       _courseDetailState = TrainProgramLoadState.loaded;
     } on UnauthenticatedException {
+      if (generation != _courseDetailGeneration) return;
       _courseDetailState = TrainProgramLoadState.error;
       _courseDetailError = LoadErrorType.sessionExpired;
     } on ServiceException catch (_) {
+      if (generation != _courseDetailGeneration) return;
       _courseDetailState = TrainProgramLoadState.error;
       _courseDetailError = campusNetworkErrorType(LoadErrorType.loadFailed);
     } catch (_) {
+      if (generation != _courseDetailGeneration) return;
       _courseDetailState = TrainProgramLoadState.error;
       _courseDetailError = campusNetworkErrorType(LoadErrorType.loadFailed);
     }
@@ -185,8 +199,10 @@ class TrainProgramProvider extends ChangeNotifier {
   }
 
   void clearCourseDetail() {
+    _courseDetailGeneration++;
     _currentCourseDetail = null;
     _courseDetailState = TrainProgramLoadState.idle;
+    _courseDetailError = null;
     _safeNotify();
   }
 }

--- a/lib/providers/user_info_provider.dart
+++ b/lib/providers/user_info_provider.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:bugaoshan/injection/injector.dart';
@@ -14,6 +16,25 @@ typedef _UserInfoResult = ({
   Map<String, dynamic>? profile,
   List<Map<String, dynamic>> labels,
 });
+typedef UserInfoPersistence =
+    Future<void> Function(String? realname, String? number);
+
+Future<void> _persistUserInfoToPreferences(
+  String? realname,
+  String? number,
+) async {
+  final prefs = getIt<SharedPreferences>();
+  if (realname == null) {
+    await prefs.remove(_keyUserRealname);
+  } else {
+    await prefs.setString(_keyUserRealname, realname);
+  }
+  if (number == null) {
+    await prefs.remove(_keyUserNumber);
+  } else {
+    await prefs.setString(_keyUserNumber, number);
+  }
+}
 
 /// 用户信息 Provider（单例）
 ///
@@ -23,9 +44,15 @@ typedef _UserInfoResult = ({
 class UserInfoProvider extends ChangeNotifier {
   final WfwAuth _wfwAuth;
   final WfwApiService _wfwApi;
+  final UserInfoPersistence _persistUserInfo;
   int _requestGeneration = 0;
+  Future<void> _persistenceTail = Future<void>.value();
 
-  UserInfoProvider(this._wfwAuth, this._wfwApi) {
+  UserInfoProvider(
+    this._wfwAuth,
+    this._wfwApi, {
+    UserInfoPersistence? persistUserInfo,
+  }) : _persistUserInfo = persistUserInfo ?? _persistUserInfoToPreferences {
     _wfwAuth.addListener(_onAuthChanged);
     // ScuAuth.init() 在 DI 阶段完成，此时本 Provider 还没创建，
     // init() 的 notifyListeners 没人接收。构造后主动检查一次。
@@ -134,10 +161,21 @@ class UserInfoProvider extends ChangeNotifier {
       _userNumber = role?['number']?.toString();
       // 同步到 ScuAuthProvider（向后兼容）
       getIt<ScuAuthProvider>().setUserInfo(_userRealname, _userNumber);
-      final prefs = getIt<SharedPreferences>();
-      await prefs.setString(_keyUserRealname, _userRealname ?? '');
-      await prefs.setString(_keyUserNumber, _userNumber ?? '');
+      await _enqueuePersistence(_userRealname, _userNumber);
     }
+  }
+
+  Future<void> _enqueuePersistence(String? realname, String? number) {
+    final operation = _persistenceTail.then(
+      (_) => _persistUserInfo(realname, number),
+    );
+    _persistenceTail = operation.then<void>(
+      (_) {},
+      onError: (Object error, StackTrace stackTrace) {
+        debugPrint('User info persistence error: $error');
+      },
+    );
+    return operation;
   }
 
   Future<void> fetchLabels() async {
@@ -178,6 +216,7 @@ class UserInfoProvider extends ChangeNotifier {
     _loading = false;
     _userRealname = null;
     _userNumber = null;
+    unawaited(_enqueuePersistence(null, null));
     notifyListeners();
   }
 

--- a/lib/providers/user_info_provider.dart
+++ b/lib/providers/user_info_provider.dart
@@ -10,6 +10,11 @@ import 'package:bugaoshan/services/auth/wfw_auth.dart';
 const _keyUserRealname = 'scu_user_realname';
 const _keyUserNumber = 'scu_user_number';
 
+typedef _UserInfoResult = ({
+  Map<String, dynamic>? profile,
+  List<Map<String, dynamic>> labels,
+});
+
 /// 用户信息 Provider（单例）
 ///
 /// 监听 [WfwAuth] 状态变化：
@@ -18,13 +23,14 @@ const _keyUserNumber = 'scu_user_number';
 class UserInfoProvider extends ChangeNotifier {
   final WfwAuth _wfwAuth;
   final WfwApiService _wfwApi;
+  int _requestGeneration = 0;
 
   UserInfoProvider(this._wfwAuth, this._wfwApi) {
     _wfwAuth.addListener(_onAuthChanged);
     // ScuAuth.init() 在 DI 阶段完成，此时本 Provider 还没创建，
     // init() 的 notifyListeners 没人接收。构造后主动检查一次。
     if (_wfwAuth.isReady) {
-      Future.microtask(_fetchAll);
+      _scheduleFetch(Duration.zero);
     }
   }
 
@@ -48,91 +54,125 @@ class UserInfoProvider extends ChangeNotifier {
       // id.scu.edu.cn 域 cookie。立即访问 wfw.scu.edu.cn 会触发重定向链，
       // 重定向期间的并发请求可能被服务端限流或产生 session 竞态导致失败。
       // 给一个短延迟让重定向链完成，同时 _fetchAll 内部有一次自动重试兜底。
-      Future.delayed(const Duration(milliseconds: 300), _fetchAll);
+      _scheduleFetch(const Duration(milliseconds: 300));
     } else if (_wfwAuth.state == AuthState.unknown) {
       clear();
     }
   }
 
+  void _scheduleFetch(Duration delay) {
+    final generation = ++_requestGeneration;
+    if (delay == Duration.zero) {
+      Future.microtask(() => _fetchAll(generation));
+    } else {
+      Future.delayed(delay, () => _fetchAll(generation));
+    }
+  }
+
+  bool _isCurrent(int generation) =>
+      generation == _requestGeneration && _wfwAuth.isReady;
+
   /// 同时获取用户信息和标签
-  Future<void> _fetchAll() async {
-    if (_loading) return;
+  Future<void> _fetchAll(int generation) async {
+    if (!_isCurrent(generation)) return;
     _loading = true;
     _error = false;
     notifyListeners();
 
-    await _doFetch();
+    final result = await _doFetch(generation);
+    if (!_isCurrent(generation)) return;
+
+    if (result == null) {
+      _error = true;
+    } else {
+      await _applyResult(result);
+      if (!_isCurrent(generation)) return;
+    }
 
     _loading = false;
     notifyListeners();
   }
 
-  Future<void> _doFetch() async {
+  Future<_UserInfoResult?> _doFetch(int generation) async {
     try {
-      await _attemptFetch();
+      return await _attemptFetch();
     } on UnauthenticatedException {
-      _error = true;
+      return null;
     } catch (_) {
       // 非认证错误（如服务端限流、网络瞬断），自动重试一次
       try {
         await Future.delayed(const Duration(seconds: 1));
-        await _attemptFetch();
+        if (!_isCurrent(generation)) return null;
+        return await _attemptFetch();
       } catch (_) {
-        _error = true;
+        return null;
       }
     }
   }
 
-  Future<void> _attemptFetch() async {
+  Future<_UserInfoResult> _attemptFetch() async {
     final results = await Future.wait([
       _wfwApi.fetchUserProfile(),
       _wfwApi.fetchProfileLabels(),
     ]);
+    return (
+      profile: results[0] as Map<String, dynamic>?,
+      labels: results[1] as List<Map<String, dynamic>>,
+    );
+  }
+
+  Future<void> _applyResult(_UserInfoResult result) async {
+    // 所有内存字段都在首次 await 前提交；若持久化期间登出，clear() 会最终清空它们。
+    _labels = result.labels;
+    _error = false;
 
     // 更新用户基本信息
-    final profile = results[0] as Map<String, dynamic>?;
+    final profile = result.profile;
     if (profile != null) {
       _userRealname = profile['realname']?.toString();
       final role = profile['role'] as Map<String, dynamic>?;
       _userNumber = role?['number']?.toString();
+      // 同步到 ScuAuthProvider（向后兼容）
+      getIt<ScuAuthProvider>().setUserInfo(_userRealname, _userNumber);
       final prefs = getIt<SharedPreferences>();
       await prefs.setString(_keyUserRealname, _userRealname ?? '');
       await prefs.setString(_keyUserNumber, _userNumber ?? '');
-      // 同步到 ScuAuthProvider（向后兼容）
-      getIt<ScuAuthProvider>().setUserInfo(_userRealname, _userNumber);
     }
-
-    // 更新标签
-    _labels = results[1] as List<Map<String, dynamic>>?;
-    _error = false;
   }
 
   Future<void> fetchLabels() async {
     if (_loading) return;
     if (!_wfwAuth.isReady) return;
+    final generation = ++_requestGeneration;
 
     _loading = true;
     _error = false;
     notifyListeners();
 
     try {
-      _labels = await _wfwApi.fetchProfileLabels();
+      final labels = await _wfwApi.fetchProfileLabels();
+      if (!_isCurrent(generation)) return;
+      _labels = labels;
       _error = false;
     } on UnauthenticatedException {
+      if (!_isCurrent(generation)) return;
       _error = true;
     } catch (e) {
+      if (!_isCurrent(generation)) return;
       _error = true;
     }
+    if (!_isCurrent(generation)) return;
     _loading = false;
     notifyListeners();
   }
 
   void retry() {
     _error = false;
-    _fetchAll();
+    if (_wfwAuth.isReady) _scheduleFetch(Duration.zero);
   }
 
   void clear() {
+    _requestGeneration++;
     _labels = null;
     _error = false;
     _loading = false;
@@ -143,6 +183,7 @@ class UserInfoProvider extends ChangeNotifier {
 
   @override
   void dispose() {
+    _requestGeneration++;
     _wfwAuth.removeListener(_onAuthChanged);
     super.dispose();
   }

--- a/lib/services/api/balance_query_service.dart
+++ b/lib/services/api/balance_query_service.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
+import 'package:bugaoshan/services/auth/scu_exceptions.dart';
 import 'package:bugaoshan/utils/constants.dart';
 import 'package:bugaoshan/utils/json_utils.dart';
 
@@ -20,11 +21,7 @@ class BalanceQueryService {
       headers: _headers,
       body: '{}',
     );
-    final json = parseJson(
-      resp.body,
-      'getCampus',
-      (msg) => BalanceQueryException(msg),
-    );
+    final json = _decodeResponse(resp, 'getCampus');
     if (json['respCode'] != '00') {
       throw BalanceQueryException(json['respDesc'] ?? '获取校区失败');
     }
@@ -44,11 +41,7 @@ class BalanceQueryService {
       headers: _headers,
       body: jsonEncode({'schoolCode': schoolCode}),
     );
-    final json = parseJson(
-      resp.body,
-      'getArchitecture',
-      (msg) => BalanceQueryException(msg),
-    );
+    final json = _decodeResponse(resp, 'getArchitecture');
     if (json['respCode'] != '00') {
       throw BalanceQueryException(json['respDesc'] ?? '获取楼栋失败');
     }
@@ -69,11 +62,7 @@ class BalanceQueryService {
       headers: _headers,
       body: jsonEncode({'schoolCode': schoolCode, 'regCode': regCode}),
     );
-    final json = parseJson(
-      resp.body,
-      'getUnit',
-      (msg) => BalanceQueryException(msg),
-    );
+    final json = _decodeResponse(resp, 'getUnit');
     if (json['respCode'] != '00') {
       throw BalanceQueryException(json['respDesc'] ?? '获取单元失败');
     }
@@ -107,11 +96,7 @@ class BalanceQueryService {
         'roomNo': roomNo,
       }),
     );
-    final json = parseJson(
-      resp.body,
-      'verificationRoom',
-      (msg) => BalanceQueryException(msg),
-    );
+    final json = _decodeResponse(resp, 'verificationRoom');
     if (json['respCode'] != '00') {
       throw BalanceQueryException(json['respDesc'] ?? '验证房间失败');
     }
@@ -129,11 +114,7 @@ class BalanceQueryService {
       headers: _headers,
       body: jsonEncode({'cusNo': cusNo, 'type': type, 'cusName': cusName}),
     );
-    final json = parseJson(
-      resp.body,
-      'queryRoomInfo',
-      (msg) => BalanceQueryException(msg),
-    );
+    final json = _decodeResponse(resp, 'queryRoomInfo');
     if (json['respCode'] != '00') {
       throw BalanceQueryException(json['respDesc'] ?? '查询失败');
     }
@@ -142,6 +123,59 @@ class BalanceQueryService {
       throw BalanceQueryException('查询数据为空');
     }
     return RoomInfo.fromJson(data);
+  }
+
+  Map<String, dynamic> _decodeResponse(http.Response response, String api) {
+    if (_isAuthenticationRedirect(response) ||
+        _isPayAppLoginTimeoutPage(response)) {
+      throw const UnauthenticatedException('缴费平台登录状态已失效');
+    }
+    return parseJson(
+      response.body,
+      api,
+      (message) => BalanceQueryException(message),
+    );
+  }
+
+  bool _isAuthenticationRedirect(http.Response response) {
+    if (response.statusCode < 300 || response.statusCode >= 400) return false;
+    final location = response.headers['location'];
+    if (location == null || location.isEmpty) return false;
+
+    try {
+      final requestUrl = response.request?.url ?? Uri.parse(_base);
+      return _isKnownAuthenticationTarget(requestUrl.resolve(location));
+    } on FormatException {
+      return false;
+    }
+  }
+
+  bool _isKnownAuthenticationTarget(Uri target) {
+    if (target.host.toLowerCase() != 'payapp.scu.edu.cn') return false;
+    return const {
+      '/eleFees/index.html',
+      '/eleFees/oauth/airWarrant',
+      '/eleFees/oauth/lightWarrant',
+    }.contains(target.path);
+  }
+
+  bool _isPayAppLoginTimeoutPage(http.Response response) {
+    final contentType = response.headers['content-type']?.toLowerCase() ?? '';
+    final decodedUtf8 = utf8.decode(response.bodyBytes, allowMalformed: true);
+    for (final body in {response.body, decodedUtf8}) {
+      final lowerBody = body.toLowerCase();
+      final looksLikeHtml =
+          contentType.contains('text/html') ||
+          lowerBody.contains('<html') ||
+          lowerBody.contains('<!doctype html');
+      final hasWarrantForm =
+          lowerBody.contains('/elefees/oauth/airwarrant') ||
+          lowerBody.contains('/elefees/oauth/lightwarrant');
+      if (looksLikeHtml && body.contains('登录超时') && hasWarrantForm) {
+        return true;
+      }
+    }
+    return false;
   }
 }
 

--- a/lib/services/api/ccyl_api_service.dart
+++ b/lib/services/api/ccyl_api_service.dart
@@ -211,7 +211,7 @@ Future<T> retryOnCcylAuthError<T>(
   try {
     return await fn();
   } on CcylAuthExpiredException {
-    auth.invalidate();
+    await auth.invalidateSession();
     final ok = await auth.reLogin();
     if (!ok) {
       throw const UnauthenticatedException('第二课堂 token 过期，重新登录失败');

--- a/lib/services/api/ccyl_api_service.dart
+++ b/lib/services/api/ccyl_api_service.dart
@@ -14,22 +14,7 @@ class CcylApiService {
   /// CCYL token 过期时服务端返回业务错误码而非 [UnauthenticatedException]。
   /// 这里捕获 [CcylException] 后清除旧 token、重新鉴权、再试一次。
   Future<T> _retryOnCcylAuthError<T>(Future<T> Function() fn) async {
-    // 首次保证 token 存在
-    await _ensureToken();
-    try {
-      return await fn();
-    } on CcylException {
-      _auth.invalidate();
-      final ok = await _auth.reLogin();
-      if (!ok) throw const UnauthenticatedException('第二课堂 token 过期，重新登录失败');
-      return await fn();
-    }
-  }
-
-  /// 获取 token，未登录时自动尝试 reLogin，失败抛 [UnauthenticatedException]。
-  Future<String> _ensureToken() async {
-    await _auth.ensureAuthenticated();
-    return _auth.token!;
+    return retryOnCcylAuthError(_auth, fn);
   }
 
   Future<List<CyclActivity>> searchActivities({
@@ -212,5 +197,25 @@ class CcylApiService {
       final token = _auth.token!;
       return CcylService.getDicts(token: token, groupCodes: groupCodes);
     });
+  }
+}
+
+/// 仅在服务端明确返回 CCYL token 失效时重新认证并重试一次。
+///
+/// 普通业务异常和网络异常直接向上抛出，避免重复提交报名、取消等非幂等请求。
+Future<T> retryOnCcylAuthError<T>(
+  CcylAuth auth,
+  Future<T> Function() fn,
+) async {
+  await auth.ensureAuthenticated();
+  try {
+    return await fn();
+  } on CcylAuthExpiredException {
+    auth.invalidate();
+    final ok = await auth.reLogin();
+    if (!ok) {
+      throw const UnauthenticatedException('第二课堂 token 过期，重新登录失败');
+    }
+    return await fn();
   }
 }

--- a/lib/services/api/wfw_api_service.dart
+++ b/lib/services/api/wfw_api_service.dart
@@ -21,12 +21,24 @@ class WfwApiService {
   }
 
   void _checkSessionExpiry(String body, int statusCode) {
-    if (statusCode == 302 || body.trim().isEmpty) {
+    if (statusCode == 302 ||
+        statusCode == 401 ||
+        statusCode == 403 ||
+        body.trim().isEmpty) {
       throw const UnauthenticatedException();
     }
-    if (body.startsWith('<') && body.contains('login')) {
+    if (body.trimLeft().startsWith('<') && body.contains('login')) {
       throw const UnauthenticatedException();
     }
+  }
+
+  Map<String, dynamic> _decodeResponse(String body, int statusCode) {
+    _checkSessionExpiry(body, statusCode);
+    final json = jsonDecode(body) as Map<String, dynamic>;
+    if (json['e'] == 10013 || json['e']?.toString() == '10013') {
+      throw const UnauthenticatedException('微服务登录已失效');
+    }
+    return json;
   }
 
   /// 获取用户信息标签
@@ -40,8 +52,7 @@ class WfwApiService {
           'Referer': 'https://wfw.scu.edu.cn',
         },
       );
-      _checkSessionExpiry(resp.body, resp.statusCode);
-      return jsonDecode(resp.body) as Map<String, dynamic>;
+      return _decodeResponse(resp.body, resp.statusCode);
     });
 
     if (json['e'] == 0 && json['d']?['labels'] != null) {
@@ -58,8 +69,7 @@ class WfwApiService {
       final resp = await client.get(
         Uri.parse('https://wfw.scu.edu.cn/uc/wap/user/get-info'),
       );
-      _checkSessionExpiry(resp.body, resp.statusCode);
-      return jsonDecode(resp.body) as Map<String, dynamic>;
+      return _decodeResponse(resp.body, resp.statusCode);
     });
 
     if (json['e'] == 0 && json['d'] != null) {

--- a/lib/services/auth/ccyl_auth.dart
+++ b/lib/services/auth/ccyl_auth.dart
@@ -176,7 +176,7 @@ class CcylAuth extends ChangeNotifier implements SubsystemAuth {
         return false;
       }
       final oauthCode = _oauthCodeProvider != null
-          ? await _oauthCodeProvider!()
+          ? await _oauthCodeProvider()
           : await CcylOAuthService(_scuAuth).getOAuthCode();
       if (!_isCurrentAttempt(generation, principal)) return false;
       if (oauthCode == null) {

--- a/lib/services/auth/ccyl_auth.dart
+++ b/lib/services/auth/ccyl_auth.dart
@@ -51,7 +51,7 @@ class CcylAuth extends ChangeNotifier implements SubsystemAuth {
         realname: '',
         orgName: '',
       );
-      _log.i(_tag, 'init: token restored userId=$userId');
+      _log.i(_tag, 'init: token restored');
     } else {
       _log.d(_tag, 'init: no saved token');
     }
@@ -83,7 +83,7 @@ class CcylAuth extends ChangeNotifier implements SubsystemAuth {
     _token = result.token;
     _currentUser = result.user;
     await _saveToSecure();
-    _log.i(_tag, 'loginWithCode: ok userId=${result.user.id}');
+    _log.i(_tag, 'loginWithCode: ok');
     notifyListeners();
   }
 
@@ -111,7 +111,7 @@ class CcylAuth extends ChangeNotifier implements SubsystemAuth {
       _token = result.token;
       _currentUser = result.user;
       await _saveToSecure();
-      _log.i(_tag, 'reLogin: ok userId=${result.user.id}');
+      _log.i(_tag, 'reLogin: ok');
       notifyListeners();
       return true;
     } catch (e) {

--- a/lib/services/auth/ccyl_auth.dart
+++ b/lib/services/auth/ccyl_auth.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/foundation.dart';
 import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/pages/campus/ccyl/models/ccyl_models.dart';
@@ -11,6 +13,11 @@ import 'package:bugaoshan/utils/auth_logger.dart';
 
 const _keyCcylToken = 'ccyl_token';
 const _keyCcylUserId = 'ccyl_user_id';
+const _keyCcylSession = 'ccyl_session_v2';
+
+typedef CcylLoginResult = ({String token, CcylUser user});
+typedef CcylLoginCallback = Future<CcylLoginResult> Function(String code);
+typedef CcylOAuthCodeProvider = Future<String?> Function();
 
 /// 第二课堂认证（第2层）
 ///
@@ -22,12 +29,21 @@ class CcylAuth extends ChangeNotifier implements SubsystemAuth {
 
   final ScuAuth _scuAuth;
   final AuthLogger _log;
+  final CcylLoginCallback _login;
+  final CcylOAuthCodeProvider? _oauthCodeProvider;
   String? _token;
   CcylUser? _currentUser;
+  String? _boundScuPrincipal;
   Future<bool>? _reLoginFuture;
 
-  CcylAuth(this._scuAuth, {AuthLogger? logger})
-    : _log = logger ?? getIt<AuthLogger>();
+  CcylAuth(
+    this._scuAuth, {
+    AuthLogger? logger,
+    CcylLoginCallback? login,
+    CcylOAuthCodeProvider? oauthCodeProvider,
+  }) : _log = logger ?? getIt<AuthLogger>(),
+       _login = login ?? CcylService.login,
+       _oauthCodeProvider = oauthCodeProvider;
 
   @override
   String get moduleId => 'ccyl';
@@ -35,16 +51,44 @@ class CcylAuth extends ChangeNotifier implements SubsystemAuth {
   @override
   List<SubsystemAuth> get dependencies => const [];
 
-  String? get token => _token;
-  bool get isLoggedIn => _token != null;
-  CcylUser? get currentUser => _currentUser;
+  bool get _isBoundToCurrentPrincipal =>
+      _token != null &&
+      _boundScuPrincipal != null &&
+      _boundScuPrincipal == _scuAuth.principal;
+
+  String? get token => _isBoundToCurrentPrincipal ? _token : null;
+  bool get isLoggedIn => _isBoundToCurrentPrincipal;
+  CcylUser? get currentUser => _isBoundToCurrentPrincipal ? _currentUser : null;
 
   /// 从安全存储恢复 token（应用启动时调用）。
   Future<void> init() async {
     final secure = SecureStorageProvider.instance;
-    _token = await secure.read(key: _keyCcylToken);
-    final userId = await secure.read(key: _keyCcylUserId);
-    if (_token != null && userId != null) {
+    final raw = await secure.read(key: _keyCcylSession);
+    await secure.delete(key: _keyCcylToken);
+    await secure.delete(key: _keyCcylUserId);
+    if (raw == null) {
+      _log.d(_tag, 'init: no saved token');
+      return;
+    }
+
+    try {
+      final session = jsonDecode(raw) as Map<String, dynamic>;
+      final token = session['token']?.toString();
+      final userId = session['userId']?.toString();
+      final principal = session['scuPrincipal']?.toString();
+      final currentPrincipal = _scuAuth.principal;
+      if (token == null ||
+          userId == null ||
+          principal == null ||
+          currentPrincipal == null ||
+          principal != currentPrincipal) {
+        _log.w(_tag, 'init: principal mismatch, discarding saved token');
+        await _clearPersistedSession();
+        return;
+      }
+
+      _token = token;
+      _boundScuPrincipal = principal;
       _currentUser = CcylUser(
         id: userId,
         userName: '',
@@ -52,36 +96,53 @@ class CcylAuth extends ChangeNotifier implements SubsystemAuth {
         orgName: '',
       );
       _log.i(_tag, 'init: token restored');
-    } else {
-      _log.d(_tag, 'init: no saved token');
+    } catch (_) {
+      _log.w(_tag, 'init: malformed saved session, discarding');
+      await _clearPersistedSession();
     }
   }
 
   /// 获取当前 token，未登录时抛 [UnauthenticatedException]。
   String requireToken() {
-    if (_token == null) throw const UnauthenticatedException('第二课堂未登录');
-    return _token!;
+    final currentToken = token;
+    if (currentToken == null) {
+      throw const UnauthenticatedException('第二课堂未登录');
+    }
+    return currentToken;
   }
 
   @override
   Future<void> ensureAuthenticated() async {
-    if (_token != null) return;
+    if (_isBoundToCurrentPrincipal) return;
+    if (_token != null || _currentUser != null || _boundScuPrincipal != null) {
+      _clearMemorySession();
+      await _clearPersistedSession();
+    }
     final ok = await reLogin();
     if (!ok) throw const UnauthenticatedException('第二课堂未登录');
   }
 
   /// 获取当前用户 ID，未登录时抛 [UnauthenticatedException]。
   String requireUserId() {
-    if (_currentUser == null) throw const UnauthenticatedException('第二课堂未登录');
-    return _currentUser!.id;
+    final user = currentUser;
+    if (user == null) throw const UnauthenticatedException('第二课堂未登录');
+    return user.id;
   }
 
   /// 使用 OAuth code 登录。
   Future<void> loginWithCode(String code) async {
     _log.i(_tag, 'loginWithCode: start');
-    final result = await CcylService.login(code);
+    final principal = _scuAuth.principal;
+    if (principal == null) {
+      throw const UnauthenticatedException('无法确认当前校园账号，请重新登录');
+    }
+    final result = await _login(code);
+    if (_scuAuth.principal != principal) {
+      throw const UnauthenticatedException('校园账号已切换，请重新授权');
+    }
     _token = result.token;
     _currentUser = result.user;
+    _boundScuPrincipal = principal;
     await _saveToSecure();
     _log.i(_tag, 'loginWithCode: ok');
     notifyListeners();
@@ -101,15 +162,26 @@ class CcylAuth extends ChangeNotifier implements SubsystemAuth {
 
   Future<bool> _doReLogin() async {
     try {
-      final oauth = CcylOAuthService(_scuAuth);
-      final oauthCode = await oauth.getOAuthCode();
+      final principal = _scuAuth.principal;
+      if (principal == null) {
+        _log.w(_tag, 'reLogin: current principal unavailable');
+        return false;
+      }
+      final oauthCode = _oauthCodeProvider != null
+          ? await _oauthCodeProvider!()
+          : await CcylOAuthService(_scuAuth).getOAuthCode();
       if (oauthCode == null) {
         _log.w(_tag, 'reLogin: oauth code missing');
         return false;
       }
-      final result = await CcylService.login(oauthCode);
+      final result = await _login(oauthCode);
+      if (_scuAuth.principal != principal) {
+        _log.w(_tag, 'reLogin: principal changed, discarding response');
+        return false;
+      }
       _token = result.token;
       _currentUser = result.user;
+      _boundScuPrincipal = principal;
       await _saveToSecure();
       _log.i(_tag, 'reLogin: ok');
       notifyListeners();
@@ -127,21 +199,43 @@ class CcylAuth extends ChangeNotifier implements SubsystemAuth {
   }
 
   Future<void> _saveToSecure() async {
-    final secure = SecureStorageProvider.instance;
-    await secure.write(key: _keyCcylToken, value: _token!);
-    if (_currentUser != null) {
-      await secure.write(key: _keyCcylUserId, value: _currentUser!.id);
+    final token = _token;
+    final user = _currentUser;
+    final principal = _boundScuPrincipal;
+    if (token == null || user == null || principal == null) {
+      throw StateError('Cannot persist an incomplete CCYL session');
     }
+    final secure = SecureStorageProvider.instance;
+    await secure.write(
+      key: _keyCcylSession,
+      value: jsonEncode({
+        'token': token,
+        'userId': user.id,
+        'scuPrincipal': principal,
+      }),
+    );
+    await secure.delete(key: _keyCcylToken);
+    await secure.delete(key: _keyCcylUserId);
   }
 
   Future<void> logout() async {
     _log.i(_tag, 'logout');
+    _clearMemorySession();
+    _reLoginFuture = null;
+    await _clearPersistedSession();
+    notifyListeners();
+  }
+
+  void _clearMemorySession() {
     _token = null;
     _currentUser = null;
-    _reLoginFuture = null;
+    _boundScuPrincipal = null;
+  }
+
+  Future<void> _clearPersistedSession() async {
     final secure = SecureStorageProvider.instance;
+    await secure.delete(key: _keyCcylSession);
     await secure.delete(key: _keyCcylToken);
     await secure.delete(key: _keyCcylUserId);
-    notifyListeners();
   }
 }

--- a/lib/services/auth/ccyl_auth.dart
+++ b/lib/services/auth/ccyl_auth.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
@@ -35,6 +36,8 @@ class CcylAuth extends ChangeNotifier implements SubsystemAuth {
   CcylUser? _currentUser;
   String? _boundScuPrincipal;
   Future<bool>? _reLoginFuture;
+  int _authGeneration = 0;
+  Future<void> _storageTail = Future.value();
 
   CcylAuth(
     this._scuAuth, {
@@ -115,8 +118,7 @@ class CcylAuth extends ChangeNotifier implements SubsystemAuth {
   Future<void> ensureAuthenticated() async {
     if (_isBoundToCurrentPrincipal) return;
     if (_token != null || _currentUser != null || _boundScuPrincipal != null) {
-      _clearMemorySession();
-      await _clearPersistedSession();
+      await invalidateSession();
     }
     final ok = await reLogin();
     if (!ok) throw const UnauthenticatedException('第二课堂未登录');
@@ -132,18 +134,20 @@ class CcylAuth extends ChangeNotifier implements SubsystemAuth {
   /// 使用 OAuth code 登录。
   Future<void> loginWithCode(String code) async {
     _log.i(_tag, 'loginWithCode: start');
+    final generation = ++_authGeneration;
+    _reLoginFuture = null;
     final principal = _scuAuth.principal;
     if (principal == null) {
       throw const UnauthenticatedException('无法确认当前校园账号，请重新登录');
     }
     final result = await _login(code);
-    if (_scuAuth.principal != principal) {
+    if (!_isCurrentAttempt(generation, principal)) {
       throw const UnauthenticatedException('校园账号已切换，请重新授权');
     }
-    _token = result.token;
-    _currentUser = result.user;
-    _boundScuPrincipal = principal;
-    await _saveToSecure();
+    final committed = await _commitLogin(result, principal, generation);
+    if (!committed) {
+      throw const UnauthenticatedException('第二课堂授权已取消');
+    }
     _log.i(_tag, 'loginWithCode: ok');
     notifyListeners();
   }
@@ -152,37 +156,40 @@ class CcylAuth extends ChangeNotifier implements SubsystemAuth {
   Future<bool> reLogin() async {
     if (_reLoginFuture != null) return _reLoginFuture!;
     _log.i(_tag, 'reLogin: starting');
-    _reLoginFuture = _doReLogin();
+    final generation = _authGeneration;
+    final future = _doReLogin(generation);
+    _reLoginFuture = future;
     try {
-      return await _reLoginFuture!;
+      return await future;
     } finally {
-      _reLoginFuture = null;
+      if (identical(_reLoginFuture, future)) {
+        _reLoginFuture = null;
+      }
     }
   }
 
-  Future<bool> _doReLogin() async {
+  Future<bool> _doReLogin(int generation) async {
     try {
       final principal = _scuAuth.principal;
-      if (principal == null) {
+      if (principal == null || !_isCurrentAttempt(generation, principal)) {
         _log.w(_tag, 'reLogin: current principal unavailable');
         return false;
       }
       final oauthCode = _oauthCodeProvider != null
           ? await _oauthCodeProvider!()
           : await CcylOAuthService(_scuAuth).getOAuthCode();
+      if (!_isCurrentAttempt(generation, principal)) return false;
       if (oauthCode == null) {
         _log.w(_tag, 'reLogin: oauth code missing');
         return false;
       }
       final result = await _login(oauthCode);
-      if (_scuAuth.principal != principal) {
-        _log.w(_tag, 'reLogin: principal changed, discarding response');
+      if (!_isCurrentAttempt(generation, principal)) {
+        _log.w(_tag, 'reLogin: attempt superseded, discarding response');
         return false;
       }
-      _token = result.token;
-      _currentUser = result.user;
-      _boundScuPrincipal = principal;
-      await _saveToSecure();
+      final committed = await _commitLogin(result, principal, generation);
+      if (!committed) return false;
       _log.i(_tag, 'reLogin: ok');
       notifyListeners();
       return true;
@@ -195,35 +202,61 @@ class CcylAuth extends ChangeNotifier implements SubsystemAuth {
   @override
   void invalidate() {
     _log.d(_tag, 'invalidate');
-    _reLoginFuture = null;
+    _cancelCurrentAuthentication();
+    unawaited(_clearPersistedSession());
   }
 
-  Future<void> _saveToSecure() async {
-    final token = _token;
-    final user = _currentUser;
-    final principal = _boundScuPrincipal;
-    if (token == null || user == null || principal == null) {
-      throw StateError('Cannot persist an incomplete CCYL session');
-    }
-    final secure = SecureStorageProvider.instance;
-    await secure.write(
-      key: _keyCcylSession,
-      value: jsonEncode({
-        'token': token,
-        'userId': user.id,
-        'scuPrincipal': principal,
-      }),
-    );
-    await secure.delete(key: _keyCcylToken);
-    await secure.delete(key: _keyCcylUserId);
+  Future<void> invalidateSession() async {
+    _log.d(_tag, 'invalidateSession');
+    _cancelCurrentAuthentication();
+    await _clearPersistedSession();
+  }
+
+  Future<bool> _commitLogin(
+    CcylLoginResult result,
+    String principal,
+    int generation,
+  ) async {
+    if (!_isCurrentAttempt(generation, principal)) return false;
+
+    final persisted = await _serializeStorage(() async {
+      if (!_isCurrentAttempt(generation, principal)) return false;
+      final secure = SecureStorageProvider.instance;
+      await secure.write(
+        key: _keyCcylSession,
+        value: jsonEncode({
+          'token': result.token,
+          'userId': result.user.id,
+          'scuPrincipal': principal,
+        }),
+      );
+      await secure.delete(key: _keyCcylToken);
+      await secure.delete(key: _keyCcylUserId);
+      return _isCurrentAttempt(generation, principal);
+    });
+    if (!persisted || !_isCurrentAttempt(generation, principal)) return false;
+
+    _token = result.token;
+    _currentUser = result.user;
+    _boundScuPrincipal = principal;
+    return true;
   }
 
   Future<void> logout() async {
     _log.i(_tag, 'logout');
-    _clearMemorySession();
-    _reLoginFuture = null;
+    _cancelCurrentAuthentication();
     await _clearPersistedSession();
     notifyListeners();
+  }
+
+  void _cancelCurrentAuthentication() {
+    _authGeneration++;
+    _reLoginFuture = null;
+    _clearMemorySession();
+  }
+
+  bool _isCurrentAttempt(int generation, String principal) {
+    return generation == _authGeneration && _scuAuth.principal == principal;
   }
 
   void _clearMemorySession() {
@@ -233,9 +266,17 @@ class CcylAuth extends ChangeNotifier implements SubsystemAuth {
   }
 
   Future<void> _clearPersistedSession() async {
-    final secure = SecureStorageProvider.instance;
-    await secure.delete(key: _keyCcylSession);
-    await secure.delete(key: _keyCcylToken);
-    await secure.delete(key: _keyCcylUserId);
+    await _serializeStorage(() async {
+      final secure = SecureStorageProvider.instance;
+      await secure.delete(key: _keyCcylSession);
+      await secure.delete(key: _keyCcylToken);
+      await secure.delete(key: _keyCcylUserId);
+    });
+  }
+
+  Future<T> _serializeStorage<T>(Future<T> Function() action) {
+    final run = _storageTail.then((_) => action());
+    _storageTail = run.then<void>((_) {}, onError: (_, _) {});
+    return run;
   }
 }

--- a/lib/services/auth/cookie_client.dart
+++ b/lib/services/auth/cookie_client.dart
@@ -7,7 +7,15 @@ import 'package:bugaoshan/utils/constants.dart';
 /// Cookie 感知的 http.Client，按域名隔离存储，发送时只带当前请求域的 cookie。
 class CookieClient extends http.BaseClient {
   static const String _tag = 'CookieClient';
-  http.Client _inner = http.Client();
+  static const Set<String> _sensitiveRedirectHeaders = {
+    'authorization',
+    'proxy-authorization',
+    'cookie',
+  };
+
+  http.Client _inner;
+
+  CookieClient({http.Client? inner}) : _inner = inner ?? http.Client();
 
   // 按域名存 cookie：host -> {name: value}
   final _jar = <String, Map<String, String>>{};
@@ -71,6 +79,7 @@ class CookieClient extends http.BaseClient {
   Future<http.Response> followRedirects(
     Uri url, {
     Map<String, String>? headers,
+    Set<Uri> sensitiveHeaderAllowedOrigins = const {},
     int maxRedirects = 10,
   }) async {
     Uri current = url;
@@ -80,7 +89,12 @@ class CookieClient extends http.BaseClient {
     for (int i = 0; i <= maxRedirects; i++) {
       final cookies = _cookiesFor(current);
       final reqHeaders = <String, String>{
-        ...?headers,
+        ..._redirectHeadersForHop(
+          initialUrl: url,
+          currentUrl: current,
+          headers: headers,
+          allowedOrigins: sensitiveHeaderAllowedOrigins,
+        ),
         if (cookies.isNotEmpty)
           'Cookie': cookies.entries
               .map((e) => '${e.key}=${e.value}')
@@ -128,6 +142,32 @@ class CookieClient extends http.BaseClient {
       'SSO 重定向链超过上限',
       statusCode: lastResponse?.statusCode,
     );
+  }
+
+  Map<String, String> _redirectHeadersForHop({
+    required Uri initialUrl,
+    required Uri currentUrl,
+    required Map<String, String>? headers,
+    required Set<Uri> allowedOrigins,
+  }) {
+    if (headers == null || headers.isEmpty) return const {};
+
+    final mayForwardSensitive =
+        _isSameOrigin(initialUrl, currentUrl) ||
+        allowedOrigins.any((origin) => _isSameOrigin(origin, currentUrl));
+    if (mayForwardSensitive) return headers;
+
+    return Map.fromEntries(
+      headers.entries.where(
+        (entry) => !_sensitiveRedirectHeaders.contains(entry.key.toLowerCase()),
+      ),
+    );
+  }
+
+  bool _isSameOrigin(Uri left, Uri right) {
+    return left.scheme.toLowerCase() == right.scheme.toLowerCase() &&
+        left.host.toLowerCase() == right.host.toLowerCase() &&
+        left.port == right.port;
   }
 
   @override

--- a/lib/services/auth/scu_auth.dart
+++ b/lib/services/auth/scu_auth.dart
@@ -153,7 +153,7 @@ class ScuAuth extends ChangeNotifier {
     required String captchaCode,
     required String captchaText,
   }) async {
-    _log.i('ScuAuth', 'login: start user=$username');
+    _log.i('ScuAuth', 'login: start');
     // 1. 获取 SM2 公钥（服务端偶发 500，加重试）
     Map<String, dynamic>? sm2Data;
     String? lastSm2Body;
@@ -482,10 +482,7 @@ class ScuAuth extends ChangeNotifier {
       _log.d('ScuAuth', 'autoLogin: no saved credentials');
       return false;
     }
-    _log.i(
-      'ScuAuth',
-      'autoLogin: starting for user=${credentials['username']}',
-    );
+    _log.i('ScuAuth', 'autoLogin: starting');
 
     try {
       final captcha = await fetchCaptcha();

--- a/lib/services/auth/scu_auth.dart
+++ b/lib/services/auth/scu_auth.dart
@@ -47,6 +47,7 @@ class ScuAuth extends ChangeNotifier {
 
   final SharedPreferences _prefs;
   final AuthLogger _log;
+  final CookieClient Function() _cookieClientFactory;
 
   String? _accessToken;
   int? _loginTimestamp;
@@ -62,8 +63,12 @@ class ScuAuth extends ChangeNotifier {
   /// 用于在 UI 层显示提示（如 snackbar），由 SessionExpiredListener 注册。
   VoidCallback? onSessionExpired;
 
-  ScuAuth(this._prefs, {AuthLogger? logger})
-    : _log = logger ?? getIt<AuthLogger>();
+  ScuAuth(
+    this._prefs, {
+    AuthLogger? logger,
+    CookieClient Function()? cookieClientFactory,
+  }) : _log = logger ?? getIt<AuthLogger>(),
+       _cookieClientFactory = cookieClientFactory ?? (() => CookieClient());
 
   // ─── 状态 ───────────────────────────────────────────────────────
 
@@ -280,7 +285,7 @@ class ScuAuth extends ChangeNotifier {
   }
 
   Future<CookieClient> _doBindSession() async {
-    final client = CookieClient();
+    final client = _cookieClientFactory();
 
     // ── Step 1: 保存 token 到服务端 session（必须成功）
     final sessionResp = await client.post(
@@ -288,11 +293,22 @@ class ScuAuth extends ChangeNotifier {
       headers: {..._headers, 'Authorization': 'Bearer $_accessToken'},
       body: '{}',
     );
+    if (sessionResp.statusCode == 401 || sessionResp.statusCode == 403) {
+      _log.w(
+        'ScuAuth',
+        'bindSession: token rejected (${sessionResp.statusCode})',
+      );
+      throw const UnauthenticatedException('统一认证 token 已失效');
+    }
     final sessionResult = parseJson(
       sessionResp.body,
       'session/save',
       (msg) => ScuLoginException(msg),
     );
+    if (sessionResult['error']?.toString().toLowerCase() == 'invalid_token') {
+      _log.w('ScuAuth', 'bindSession: invalid_token response');
+      throw const UnauthenticatedException('统一认证 token 已失效');
+    }
     if (sessionResult['success'] != true) {
       _log.w('ScuAuth', 'bindSession: session/save rejected');
       throw ScuLoginException('session/save 失败: ${sessionResp.body}');
@@ -330,13 +346,26 @@ class ScuAuth extends ChangeNotifier {
         onSessionExpired?.call();
         throw const UnauthenticatedException();
       }
+
+      return await bindSession();
     }
 
     if (_accessToken == null) {
       throw const UnauthenticatedException('未登录');
     }
 
-    return await bindSession();
+    try {
+      return await bindSession();
+    } on UnauthenticatedException {
+      _log.w('ScuAuth', 'getClient: server rejected token, refreshing');
+      final refreshed = await _synchronizedRefresh();
+      if (!refreshed) {
+        _log.e('ScuAuth', 'getClient: refresh failed, session expired');
+        onSessionExpired?.call();
+        throw const UnauthenticatedException();
+      }
+      return await bindSession();
+    }
   }
 
   /// 获取 access token（给 WfwAuth 等需要 Bearer token 的场景）。

--- a/lib/services/auth/scu_auth.dart
+++ b/lib/services/auth/scu_auth.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:crypto/crypto.dart';
 import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/utils/secure_storage.dart';
 import 'package:bugaoshan/services/auth/auth_state.dart';
@@ -19,6 +20,7 @@ import 'package:bugaoshan/utils/sm2_crypto.dart';
 const kZhjwBase = 'http://zhjw.scu.edu.cn';
 
 const _keyAccessToken = 'scu_access_token';
+const _keyPrincipalBinding = 'scu_principal_binding_v1';
 const _keyLoginTimestamp = 'scu_login_timestamp';
 const _sessionDurationSeconds = 3600;
 
@@ -50,6 +52,7 @@ class ScuAuth extends ChangeNotifier {
   final CookieClient Function() _cookieClientFactory;
 
   String? _accessToken;
+  String? _principal;
   int? _loginTimestamp;
   CookieClient? _cachedClient;
   Future<CookieClient>? _bindSessionFuture;
@@ -82,6 +85,7 @@ class ScuAuth extends ChangeNotifier {
   }
 
   String? get accessToken => _accessToken;
+  String? get principal => _principal;
 
   @protected
   set state(AuthState value) {
@@ -100,6 +104,7 @@ class ScuAuth extends ChangeNotifier {
     _accessToken = await SecureStorageProvider.instance.read(
       key: _keyAccessToken,
     );
+    _principal = await _restorePrincipal(_accessToken);
     _loginTimestamp = _prefs.getInt(_keyLoginTimestamp);
 
     if (_accessToken != null && !isExpired) {
@@ -246,12 +251,18 @@ class ScuAuth extends ChangeNotifier {
 
     // 登录成功
     _accessToken = token;
+    _principal = username;
     _cachedClient = null;
     _bindSessionFuture = null;
     _loginTimestamp = DateTime.now().millisecondsSinceEpoch ~/ 1000;
-    await SecureStorageProvider.instance.write(
-      key: _keyAccessToken,
-      value: _accessToken!,
+    final secure = SecureStorageProvider.instance;
+    await secure.write(key: _keyAccessToken, value: _accessToken!);
+    await secure.write(
+      key: _keyPrincipalBinding,
+      value: jsonEncode({
+        'principal': _principal,
+        'tokenFingerprint': _tokenFingerprint(_accessToken!),
+      }),
     );
     await _prefs.setInt(_keyLoginTimestamp, _loginTimestamp!);
     _log.i('ScuAuth', 'login: ok, token len=${token.length}');
@@ -463,13 +474,42 @@ class ScuAuth extends ChangeNotifier {
   Future<void> logout() async {
     _log.i('ScuAuth', 'logout: clearing session');
     _accessToken = null;
+    _principal = null;
     _cachedClient = null;
     _bindSessionFuture = null;
     _refreshCompleter = null;
     _loginTimestamp = null;
     await SecureStorageProvider.instance.delete(key: _keyAccessToken);
+    await SecureStorageProvider.instance.delete(key: _keyPrincipalBinding);
     await _prefs.remove(_keyLoginTimestamp);
     state = AuthState.unknown;
+  }
+
+  Future<String?> _restorePrincipal(String? token) async {
+    if (token == null) return null;
+    final secure = SecureStorageProvider.instance;
+    final raw = await secure.read(key: _keyPrincipalBinding);
+    if (raw == null) return null;
+
+    try {
+      final binding = jsonDecode(raw) as Map<String, dynamic>;
+      final principal = binding['principal']?.toString();
+      final fingerprint = binding['tokenFingerprint']?.toString();
+      if (principal == null ||
+          principal.isEmpty ||
+          fingerprint != _tokenFingerprint(token)) {
+        await secure.delete(key: _keyPrincipalBinding);
+        return null;
+      }
+      return principal;
+    } catch (_) {
+      await secure.delete(key: _keyPrincipalBinding);
+      return null;
+    }
+  }
+
+  String _tokenFingerprint(String token) {
+    return sha256.convert(utf8.encode(token)).toString();
   }
 
   // ─── 凭据管理（自动登录用）──────────────────────────────────

--- a/lib/services/auth/wfw_auth.dart
+++ b/lib/services/auth/wfw_auth.dart
@@ -3,6 +3,7 @@ import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/services/auth/auth_state.dart';
 import 'package:bugaoshan/services/auth/scu_auth.dart';
 import 'package:bugaoshan/services/auth/cookie_client.dart';
+import 'package:bugaoshan/services/auth/scu_exceptions.dart';
 import 'package:bugaoshan/services/auth/subsystem_auth.dart';
 import 'package:bugaoshan/utils/auth_logger.dart';
 import 'package:bugaoshan/utils/constants.dart';
@@ -20,6 +21,8 @@ class WfwAuth extends ChangeNotifier implements SubsystemAuth {
   final ScuAuth _scuAuth;
   final AuthLogger _log;
   bool _ready = false;
+  CookieClient? _lastScuClient;
+  Future<void>? _warmUpFuture;
 
   WfwAuth(this._scuAuth, {AuthLogger? logger})
     : _log = logger ?? getIt<AuthLogger>() {
@@ -30,6 +33,8 @@ class WfwAuth extends ChangeNotifier implements SubsystemAuth {
     if (_scuAuth.state == AuthState.unknown) {
       if (_ready) _log.d(_tag, 'scu logged out, marking not ready');
       _ready = false;
+      _lastScuClient = null;
+      _warmUpFuture = null;
     }
     notifyListeners();
   }
@@ -45,39 +50,71 @@ class WfwAuth extends ChangeNotifier implements SubsystemAuth {
 
   @override
   Future<void> ensureAuthenticated() async {
-    if (_ready) return;
-    _log.d(_tag, 'ensureAuthenticated: warming wfw session');
     final client = await _scuAuth.getClient();
+    await _ensureClientReady(client);
+  }
+
+  Future<void> _ensureClientReady(CookieClient client) async {
+    if (!identical(client, _lastScuClient)) {
+      final wasReady = _ready;
+      _log.d(_tag, 'scu client changed, clearing ready state');
+      _lastScuClient = client;
+      _warmUpFuture = null;
+      _ready = false;
+      if (wasReady) notifyListeners();
+    }
+
+    if (_ready) return;
+    final existing = _warmUpFuture;
+    if (existing != null) {
+      await existing;
+      return;
+    }
+
+    final future = _warmUp(client);
+    _warmUpFuture = future;
+    try {
+      await future;
+    } finally {
+      if (identical(_warmUpFuture, future)) {
+        _warmUpFuture = null;
+      }
+    }
+  }
+
+  Future<void> _warmUp(CookieClient client) async {
+    _log.d(_tag, 'ensureAuthenticated: warming wfw session');
     // 预热 wfw session：不带 AJAX header 访问 wfw 首页，触发 SSO
     // 重定向链，在 CookieClient 中建立 wfw.scu.edu.cn 的 session cookie。
     // 不这么做的话，冷启动时页面带 X-Requested-With 的 API 请求会被
     // wfw 服务端直接返回 "用户信息已失效" 而不走 SSO 重定向。
     try {
-      await client.followRedirects(
+      final response = await client.followRedirects(
         Uri.parse('https://wfw.scu.edu.cn/'),
         headers: {'User-Agent': kDefaultUserAgent},
       );
+      if (response.statusCode == 401 || response.statusCode == 403) {
+        throw const UnauthenticatedException('微服务登录已失效');
+      }
+      if (response.statusCode < 200 || response.statusCode >= 400) {
+        throw ServiceException('微服务预热失败', statusCode: response.statusCode);
+      }
       _log.d(_tag, 'warm-up request ok');
-      if (!_ready) {
+      if (identical(client, _lastScuClient) && !_ready) {
         _ready = true;
         _log.i(_tag, 'ready');
         notifyListeners();
       }
     } catch (e) {
-      _log.w(_tag, 'warm-up request failed (non-fatal): $e');
-      // 预热失败不标记 ready，页面保持 spinner 等待重试。
-      // getClient() 的 lazy-ready 会在实际 API 调用时兜底。
+      _log.w(_tag, 'warm-up request failed: $e');
+      rethrow;
     }
   }
 
   /// 获取已认证的 CookieClient（SSO session）。
   Future<CookieClient> getClient() async {
     final client = await _scuAuth.getClient();
-    if (!_ready) {
-      _ready = true;
-      _log.d(_tag, 'getClient: lazy-ready');
-      notifyListeners();
-    }
+    await _ensureClientReady(client);
     return client;
   }
 
@@ -85,6 +122,8 @@ class WfwAuth extends ChangeNotifier implements SubsystemAuth {
   void invalidate() {
     if (_ready) _log.d(_tag, 'invalidate');
     _ready = false;
+    _lastScuClient = null;
+    _warmUpFuture = null;
   }
 
   @override

--- a/lib/services/ccyl/ccyl_service.dart
+++ b/lib/services/ccyl/ccyl_service.dart
@@ -369,6 +369,8 @@ class CcylService {
                 .toList();
           }
         }
+      } on CcylAuthExpiredException {
+        rethrow;
       } on CcylException {
         // 忽略单个字典请求失败
       }
@@ -393,7 +395,9 @@ class CcylService {
       if (resp.statusCode != 200) {
         throw CcylException('[$api] HTTP 错误: ${resp.statusCode}');
       }
-      return parseJson(resp.body, api, (msg) => CcylException(msg));
+      final json = parseJson(resp.body, api, (msg) => CcylException(msg));
+      _throwOnAuthExpiry(json);
+      return json;
     } on CcylException {
       rethrow;
     } catch (e) {
@@ -411,14 +415,27 @@ class CcylService {
       if (resp.statusCode != 200) {
         throw CcylException('[$api] HTTP 错误: ${resp.statusCode}');
       }
-      return parseJson(resp.body, api, (msg) => CcylException(msg));
+      final json = parseJson(resp.body, api, (msg) => CcylException(msg));
+      _throwOnAuthExpiry(json);
+      return json;
     } on CcylException {
       rethrow;
     } catch (e) {
       throw CcylException('[$api] 网络请求失败: $e');
     }
   }
+
+  static void _throwOnAuthExpiry(Map<String, dynamic> json) {
+    if (isCcylAuthExpiredCode(json['code'])) {
+      throw CcylAuthExpiredException(
+        json['msg']?.toString() ?? '第二课堂 token 已失效',
+      );
+    }
+  }
 }
+
+/// CCYL 当前协议用 HTTP 200 + 业务码 401 表示 token 缺失或失效。
+bool isCcylAuthExpiredCode(Object? code) => code?.toString() == '401';
 
 // ═══════════════════════════════════════════════════════════════════════
 //  异常
@@ -429,4 +446,8 @@ class CcylException implements Exception {
   const CcylException(this.message);
   @override
   String toString() => message;
+}
+
+class CcylAuthExpiredException extends CcylException {
+  const CcylAuthExpiredException(super.message);
 }

--- a/lib/services/download_manager.dart
+++ b/lib/services/download_manager.dart
@@ -43,8 +43,10 @@ class DownloadManager extends ChangeNotifier {
 
   Map<String, DownloadTask> get tasks => Map.unmodifiable(_tasks);
 
-  DownloadTask? taskFor(String dirName, String fileName) {
-    return _tasks['$dirName/$fileName'];
+  String _taskId(String url, String dirName) => '$dirName\u0000$url';
+
+  DownloadTask? taskFor(String url, String dirName) {
+    return _tasks[_taskId(url, dirName)];
   }
 
   DownloadTask enqueue(
@@ -53,7 +55,7 @@ class DownloadManager extends ChangeNotifier {
     String fileName, {
     Map<String, String>? headers,
   }) {
-    final id = '$dirName/$fileName';
+    final id = _taskId(url, dirName);
     final existing = _tasks[id];
     if (existing != null) return existing;
 
@@ -118,15 +120,20 @@ class DownloadManager extends ChangeNotifier {
     }
   }
 
-  void cancel(String dirName, String fileName) {
-    final task = taskFor(dirName, fileName);
+  void cancel(String url, String dirName) {
+    final task = taskFor(url, dirName);
     if (task != null && task.cancelToken != null) {
       task.cancelToken!.cancel();
     }
   }
 
-  void remove(String dirName, String fileName) {
-    _tasks.remove('$dirName/$fileName');
+  void remove(String url, String dirName) {
+    _tasks.remove(_taskId(url, dirName));
+    notifyListeners();
+  }
+
+  void removeByDownloadedPath(String path) {
+    _tasks.removeWhere((_, task) => task.downloadedPath == path);
     notifyListeners();
   }
 

--- a/lib/services/ics_service.dart
+++ b/lib/services/ics_service.dart
@@ -58,11 +58,7 @@ class IcsService {
       for (int week = course.startWeek; week <= course.endWeek; week++) {
         if (!_isWeekActive(course, week)) continue;
 
-        final courseDate = _getCourseDate(
-          config.semesterStartDate,
-          week,
-          course.dayOfWeek,
-        );
+        final courseDate = config.dateForCourseDay(week, course.dayOfWeek);
         final startTime = config.timeSlots[course.startSection - 1].startTime;
         final endTime = config.timeSlots[course.endSection - 1].endTime;
         final start = _combineDateTime(courseDate, startTime);
@@ -217,19 +213,6 @@ class IcsService {
     if (course.weekType == WeekType.odd && week.isEven) return false;
     if (course.weekType == WeekType.even && week.isOdd) return false;
     return true;
-  }
-
-  static DateTime _getCourseDate(
-    DateTime semesterStart,
-    int week,
-    int dayOfWeek,
-  ) {
-    // force monday alignment
-    final monday = semesterStart.toMonday();
-    final targetDate = monday.add(
-      Duration(days: (week - 1) * 7 + (dayOfWeek - 1)),
-    );
-    return DateTime(targetDate.year, targetDate.month, targetDate.day);
   }
 
   static DateTime _combineDateTime(DateTime date, TimeOfDay time) {

--- a/lib/services/update_asset_selector.dart
+++ b/lib/services/update_asset_selector.dart
@@ -1,0 +1,25 @@
+enum UpdateAssetPlatform { android, windows, linux }
+
+bool _matchesUpdatePlatform(String assetName, UpdateAssetPlatform platform) {
+  final name = assetName.toLowerCase();
+  return switch (platform) {
+    UpdateAssetPlatform.android => name.endsWith('_universal.apk'),
+    UpdateAssetPlatform.windows =>
+      name.contains('_windows_') && name.endsWith('.zip'),
+    UpdateAssetPlatform.linux =>
+      name.contains('_linux_') && name.endsWith('.tar.gz'),
+  };
+}
+
+Map<String, dynamic>? selectUpdateAsset(
+  Iterable<Map<String, dynamic>> assets,
+  UpdateAssetPlatform platform,
+) {
+  for (final asset in assets) {
+    final name = asset['name'];
+    if (name is String && _matchesUpdatePlatform(name, platform)) {
+      return asset;
+    }
+  }
+  return null;
+}

--- a/lib/services/update_service.dart
+++ b/lib/services/update_service.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/providers/app_config_provider.dart';
 import 'package:bugaoshan/providers/app_info_provider.dart';
+import 'package:bugaoshan/services/update_asset_selector.dart';
 import 'package:bugaoshan/services/update_checker.dart';
 import 'package:crypto/crypto.dart' as crypto;
 
@@ -72,12 +73,20 @@ class UpdateService {
 
   UpdateService(this._prefs, this._currentVersion);
 
-  bool _assetMatchesPlatform(String assetName) {
-    final name = assetName.toLowerCase();
-    if (Platform.isAndroid) return name.endsWith('.apk');
-    if (Platform.isWindows) return name.contains('windows');
-    if (Platform.isLinux) return name.contains('linux');
-    return false;
+  UpdateAssetPlatform? get _assetPlatform {
+    if (Platform.isAndroid) return UpdateAssetPlatform.android;
+    if (Platform.isWindows) return UpdateAssetPlatform.windows;
+    if (Platform.isLinux) return UpdateAssetPlatform.linux;
+    return null;
+  }
+
+  Map<String, dynamic>? _selectAsset(List<dynamic> assets) {
+    final platform = _assetPlatform;
+    if (platform == null) return null;
+    return selectUpdateAsset(
+      assets.whereType<Map<String, dynamic>>(),
+      platform,
+    );
   }
 
   /// Parse the `digest` field from a GitHub release asset.
@@ -115,26 +124,20 @@ class UpdateService {
       Uri.parse('https://api.github.com/repos/$_repo/releases/latest'),
       headers: {'Accept': 'application/vnd.github+json'},
     );
-    if (response.statusCode == 200) {
-      if (response.body.isEmpty) return null;
-      final data = jsonDecode(response.body);
-      final tagName = data['tag_name'] as String;
-      final isPrerelease = data['prerelease'] == true;
-      final assets = data['assets'] as List<dynamic>;
-      for (final asset in assets) {
-        final name = asset['name'] as String;
-        if (_assetMatchesPlatform(name)) {
-          return ReleaseInfo(
-            tagName: tagName,
-            downloadUrl: asset['browser_download_url'] as String,
-            checksumSha256: _parseDigest(asset as Map<String, dynamic>),
-            isPrerelease: isPrerelease,
-            body: data['body'] as String?,
-          );
-        }
-      }
+    if (response.statusCode != 200) {
+      throw Exception('GitHub API error: ${response.statusCode}');
     }
-    throw Exception('GitHub API error: ${response.statusCode}');
+    if (response.body.isEmpty) return null;
+    final data = jsonDecode(response.body);
+    final asset = _selectAsset(data['assets'] as List<dynamic>);
+    if (asset == null) return null;
+    return ReleaseInfo(
+      tagName: data['tag_name'] as String,
+      downloadUrl: asset['browser_download_url'] as String,
+      checksumSha256: _parseDigest(asset),
+      isPrerelease: data['prerelease'] == true,
+      body: data['body'] as String?,
+    );
   }
 
   Future<ReleaseInfo> getLatestPrereleaseFromGitHub() async {
@@ -149,20 +152,11 @@ class UpdateService {
         final tagName = releases[0]['tag_name'] as String;
         final isPrerelease = releases[0]['prerelease'] == true;
         final assets = releases[0]['assets'] as List<dynamic>;
-        String? downloadUrl;
-        String? checksumSha256;
-        for (final asset in assets) {
-          final name = asset['name'] as String;
-          if (_assetMatchesPlatform(name)) {
-            downloadUrl = asset['browser_download_url'] as String;
-            checksumSha256 = _parseDigest(asset as Map<String, dynamic>);
-            break;
-          }
-        }
+        final asset = _selectAsset(assets);
         return ReleaseInfo(
           tagName: tagName,
-          downloadUrl: downloadUrl,
-          checksumSha256: checksumSha256,
+          downloadUrl: asset?['browser_download_url'] as String?,
+          checksumSha256: asset == null ? null : _parseDigest(asset),
           isPrerelease: isPrerelease,
           body: releases[0]['body'] as String?,
         );
@@ -191,20 +185,11 @@ class UpdateService {
       if (release['tag_name'] == null) continue;
       final isPrerelease = release['prerelease'] == true;
       final assets = release['assets'] as List<dynamic>;
-      String? downloadUrl;
-      String? checksumSha256;
-      for (final asset in assets) {
-        final name = asset['name'] as String;
-        if (_assetMatchesPlatform(name)) {
-          downloadUrl = asset['browser_download_url'] as String;
-          checksumSha256 = _parseDigest(asset as Map<String, dynamic>);
-          break;
-        }
-      }
+      final asset = _selectAsset(assets);
       final info = ReleaseInfo(
         tagName: release['tag_name'] as String,
-        downloadUrl: downloadUrl,
-        checksumSha256: checksumSha256,
+        downloadUrl: asset?['browser_download_url'] as String?,
+        checksumSha256: asset == null ? null : _parseDigest(asset),
         isPrerelease: isPrerelease,
         body: release['body'] as String?,
       );

--- a/lib/utils/auth_logger.dart
+++ b/lib/utils/auth_logger.dart
@@ -70,6 +70,14 @@ class AuthLogRedactor {
     r'([?&](?:code|access_token)=)([^&\s"]+)',
     caseSensitive: false,
   );
+  static final RegExp _principalLabel = RegExp(
+    r'\b(user(?:name|id)?|student(?:id|number)?|number)\s*=\s*([^\s,;]+)',
+    caseSensitive: false,
+  );
+  static final RegExp _principalJson = RegExp(
+    r'("(?:username|userId|studentId|studentNumber|number)"\s*:\s*)"[^"]*"',
+    caseSensitive: false,
+  );
 
   /// 对输入文本做脱敏；返回新字符串。
   static String apply(String text) {
@@ -89,6 +97,14 @@ class AuthLogRedactor {
       if (value.length <= 4) return '$prefix<redacted>';
       return '$prefix${value.substring(0, 4)}…';
     });
+    result = result.replaceAllMapped(
+      _principalLabel,
+      (m) => '${m[1]}=<redacted>',
+    );
+    result = result.replaceAllMapped(
+      _principalJson,
+      (m) => '${m[1]}"<redacted>"',
+    );
     return result;
   }
 }

--- a/lib/utils/class_week_parser.dart
+++ b/lib/utils/class_week_parser.dart
@@ -1,0 +1,46 @@
+import 'package:bugaoshan/models/course.dart';
+
+typedef ClassWeekSegment = ({int startWeek, int endWeek, WeekType weekType});
+
+/// 将教务系统的周次位串拆成 [Course] 可精确表达的若干区间。
+///
+/// 连续周合并为 `every` 区间，完整且无缺口的单双周序列合并为一个
+/// `odd` / `even` 区间。其余稀疏模式按连续段拆分，保证不会凭空增加周次。
+List<ClassWeekSegment> parseClassWeekSegments(String classWeek) {
+  final activeWeeks = <int>[
+    for (var index = 0; index < classWeek.length; index++)
+      if (classWeek[index] == '1') index + 1,
+  ];
+  if (activeWeeks.isEmpty) return const [];
+
+  final isCompleteAlternating =
+      activeWeeks.length > 1 &&
+      activeWeeks.indexed.skip(1).every((entry) {
+        final (index, week) = entry;
+        return week - activeWeeks[index - 1] == 2;
+      });
+  if (isCompleteAlternating) {
+    return [
+      (
+        startWeek: activeWeeks.first,
+        endWeek: activeWeeks.last,
+        weekType: activeWeeks.first.isOdd ? WeekType.odd : WeekType.even,
+      ),
+    ];
+  }
+
+  final segments = <ClassWeekSegment>[];
+  var start = activeWeeks.first;
+  var end = start;
+  for (final week in activeWeeks.skip(1)) {
+    if (week == end + 1) {
+      end = week;
+      continue;
+    }
+    segments.add((startWeek: start, endWeek: end, weekType: WeekType.every));
+    start = week;
+    end = week;
+  }
+  segments.add((startWeek: start, endWeek: end, weekType: WeekType.every));
+  return segments;
+}

--- a/lib/utils/share_utils.dart
+++ b/lib/utils/share_utils.dart
@@ -1,6 +1,8 @@
 import 'dart:io';
 import 'dart:ui';
 
+import 'package:flutter/rendering.dart' show RenderBox;
+import 'package:flutter/widgets.dart' show BuildContext, View;
 import 'package:share_plus/share_plus.dart' show ShareParams, SharePlus, XFile;
 
 /// share_plus 的 Windows 兼容垫片。
@@ -18,10 +20,28 @@ String normalizeSharePath(String path) =>
 
 XFile _toXFile(String path) => XFile(normalizeSharePath(path));
 
+/// 计算分享面板的弹出锚点。iPad 要求该区域非空且位于当前视图坐标内。
+Rect sharePositionOriginForContext(BuildContext context, {Rect? preferred}) {
+  if (preferred != null && !preferred.isEmpty) return preferred;
+
+  final renderObject = context.findRenderObject();
+  if (renderObject is RenderBox &&
+      renderObject.hasSize &&
+      !renderObject.size.isEmpty) {
+    final origin = renderObject.localToGlobal(Offset.zero) & renderObject.size;
+    if (!origin.isEmpty) return origin;
+  }
+
+  final view = View.of(context);
+  final logicalSize = view.physicalSize / view.devicePixelRatio;
+  return Rect.fromLTWH(logicalSize.width / 2, logicalSize.height / 2, 1, 1);
+}
+
 /// 分享单个文件。封装 `SharePlus.instance.share(...)`，自动处理 Windows
 /// 路径分隔符问题。
 Future<void> shareSingleFile(
   String path, {
+  required BuildContext context,
   String? text,
   Rect? sharePositionOrigin,
 }) {
@@ -30,7 +50,10 @@ Future<void> shareSingleFile(
     ShareParams(
       files: [file],
       text: text,
-      sharePositionOrigin: sharePositionOrigin,
+      sharePositionOrigin: sharePositionOriginForContext(
+        context,
+        preferred: sharePositionOrigin,
+      ),
     ),
   );
 }
@@ -39,6 +62,7 @@ Future<void> shareSingleFile(
 /// 路径分隔符问题。
 Future<void> shareMultipleFiles(
   List<String> paths, {
+  required BuildContext context,
   String? text,
   Rect? sharePositionOrigin,
 }) {
@@ -46,7 +70,10 @@ Future<void> shareMultipleFiles(
     ShareParams(
       files: [for (final p in paths) _toXFile(p)],
       text: text,
-      sharePositionOrigin: sharePositionOrigin,
+      sharePositionOrigin: sharePositionOriginForContext(
+        context,
+        preferred: sharePositionOrigin,
+      ),
     ),
   );
 }

--- a/lib/widgets/common/auth_scoped_indexed_stack.dart
+++ b/lib/widgets/common/auth_scoped_indexed_stack.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+
+/// 按认证会话隔离页面状态的懒加载 [IndexedStack]。
+///
+/// 登录状态跨越边界时会销毁全部缓存页面。即使新旧页面的 Widget 类型和位置
+/// 相同，代际 key 也会强制 Flutter 丢弃旧 State，避免前一账号的本地字段或
+/// 未完成请求在新账号会话中继续生效。
+class AuthScopedIndexedStack extends StatefulWidget {
+  const AuthScopedIndexedStack({
+    super.key,
+    required this.authListenable,
+    required this.isAuthenticated,
+    required this.visibleIds,
+    required this.selectedIndex,
+    required this.pageBuilder,
+  });
+
+  final Listenable authListenable;
+  final bool Function() isAuthenticated;
+  final List<String> visibleIds;
+  final int selectedIndex;
+  final Widget Function(String id) pageBuilder;
+
+  @override
+  State<AuthScopedIndexedStack> createState() => _AuthScopedIndexedStackState();
+}
+
+class _AuthScopedIndexedStackState extends State<AuthScopedIndexedStack> {
+  final Map<String, Widget> _pageCache = {};
+  late bool _wasAuthenticated;
+  int _authGeneration = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _wasAuthenticated = widget.isAuthenticated();
+    widget.authListenable.addListener(_handleAuthChanged);
+  }
+
+  @override
+  void didUpdateWidget(covariant AuthScopedIndexedStack oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.authListenable != widget.authListenable) {
+      oldWidget.authListenable.removeListener(_handleAuthChanged);
+      widget.authListenable.addListener(_handleAuthChanged);
+    }
+    _resetForAuthenticationBoundary();
+  }
+
+  void _handleAuthChanged() {
+    if (!mounted || !_resetForAuthenticationBoundary()) return;
+    setState(() {});
+  }
+
+  bool _resetForAuthenticationBoundary() {
+    final authenticated = widget.isAuthenticated();
+    if (authenticated == _wasAuthenticated) return false;
+
+    _wasAuthenticated = authenticated;
+    _authGeneration++;
+    _pageCache.clear();
+    return true;
+  }
+
+  @override
+  void dispose() {
+    widget.authListenable.removeListener(_handleAuthChanged);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final visibleIds = widget.visibleIds;
+    if (visibleIds.isEmpty) return const SizedBox.shrink();
+
+    for (final id in visibleIds) {
+      _pageCache.putIfAbsent(
+        id,
+        () => KeyedSubtree(
+          key: ValueKey('auth-$_authGeneration-$id'),
+          child: widget.pageBuilder(id),
+        ),
+      );
+    }
+    _pageCache.keys
+        .where((id) => !visibleIds.contains(id))
+        .toList()
+        .forEach(_pageCache.remove);
+
+    final selectedIndex = widget.selectedIndex.clamp(0, visibleIds.length - 1);
+    return IndexedStack(
+      index: selectedIndex,
+      children: visibleIds.map((id) => _pageCache[id]!).toList(),
+    );
+  }
+}

--- a/lib/widgets/common/image_viewer.dart
+++ b/lib/widgets/common/image_viewer.dart
@@ -139,7 +139,8 @@ class ImageViewerPage extends StatelessWidget {
         '${dir.path}/shared_image_${DateTime.now().millisecondsSinceEpoch}.jpg',
       );
       await file.writeAsBytes(response.bodyBytes);
-      await shareSingleFile(file.path);
+      if (!context.mounted) return;
+      await shareSingleFile(file.path, context: context);
     } catch (e) {
       debugPrint('Share image error: $e');
       if (context.mounted) {

--- a/lib/widgets/course/course_grid.dart
+++ b/lib/widgets/course/course_grid.dart
@@ -15,6 +15,7 @@ class CourseGrid extends StatefulWidget {
   final int displayWeek;
   final int totalWeeks;
   final bool showAllWeeks;
+  final bool? showWeekendOverride;
   final void Function(Course course)? onCourseTap;
   final void Function(Course course)? onCourseLongPress;
   final void Function(int dayOfWeek, int section)? onEmptyTap;
@@ -27,6 +28,7 @@ class CourseGrid extends StatefulWidget {
     required this.displayWeek,
     this.totalWeeks = 20,
     this.showAllWeeks = false,
+    this.showWeekendOverride,
     this.onCourseTap,
     this.onCourseLongPress,
     this.onEmptyTap,
@@ -80,7 +82,9 @@ class _CourseGridState extends State<CourseGrid> {
         appConfig.showNonCurrentWeekCourses,
       ]),
       builder: (context, _) {
-        final dayCount = appConfig.showWeekend.value ? 7 : 5;
+        final showWeekend =
+            widget.showWeekendOverride ?? appConfig.showWeekend.value;
+        final dayCount = showWeekend ? 7 : 5;
         final hasBackground = appConfig.backgroundImagePath.value != null;
         final rowHeight = appConfig.courseRowHeight.value;
         final showCourseGrid = appConfig.showCourseGrid.value;
@@ -93,6 +97,7 @@ class _CourseGridState extends State<CourseGrid> {
               showAllWeeks: widget.showAllWeeks,
               hasBackground: hasBackground,
               sectionWidth: _sectionWidth,
+              showWeekend: showWeekend,
               onSpecialDayTap: widget.onSpecialDayTap,
             ),
             Expanded(
@@ -109,7 +114,7 @@ class _CourseGridState extends State<CourseGrid> {
                     Expanded(
                       child: Row(
                         children: List.generate(dayCount, (dayIndex) {
-                          final day = appConfig.showWeekend.value
+                          final day = showWeekend
                               ? (dayIndex == 0 ? 7 : dayIndex)
                               : dayIndex + 1;
                           List<Course> dayCourses;

--- a/lib/widgets/course/grid_header.dart
+++ b/lib/widgets/course/grid_header.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:bugaoshan/injection/injector.dart';
 import 'package:bugaoshan/l10n/app_localizations.dart';
 import 'package:bugaoshan/models/course.dart';
-import 'package:bugaoshan/providers/app_config_provider.dart';
 import 'package:bugaoshan/utils/app_shapes.dart';
 import 'package:bugaoshan/utils/holiday_utils.dart';
 
@@ -12,6 +10,7 @@ class GridHeaderRow extends StatelessWidget {
   final int displayWeek;
   final bool showAllWeeks;
   final bool hasBackground;
+  final bool showWeekend;
   final double sectionWidth;
   final void Function(DateTime date, SpecialDayInfo info)? onSpecialDayTap;
 
@@ -21,6 +20,7 @@ class GridHeaderRow extends StatelessWidget {
     required this.displayWeek,
     required this.showAllWeeks,
     required this.hasBackground,
+    required this.showWeekend,
     required this.sectionWidth,
     this.onSpecialDayTap,
   });
@@ -37,11 +37,8 @@ class GridHeaderRow extends StatelessWidget {
       l10n.friday,
       l10n.saturday,
     ];
-    final appConfig = getIt<AppConfigProvider>();
     final theme = Theme.of(context);
-    final visibleDays = appConfig.showWeekend.value
-        ? dayNames
-        : dayNames.sublist(1, 6);
+    final visibleDays = showWeekend ? dayNames : dayNames.sublist(1, 6);
 
     final now = DateTime.now();
     final today = DateTime(now.year, now.month, now.day);
@@ -71,7 +68,7 @@ class GridHeaderRow extends StatelessWidget {
               children: List.generate(visibleDays.length, (index) {
                 final name = visibleDays[index];
                 // 周日为 index 0，计算当前列对应的星期几
-                final dayOfWeek = appConfig.showWeekend.value
+                final dayOfWeek = showWeekend
                     ? (index == 0 ? 7 : index)
                     : index + 1;
                 // 周日在周一之前，dayOfWeek=7 时应为 -1 而非 6

--- a/lib/widgets/course/grid_header.dart
+++ b/lib/widgets/course/grid_header.dart
@@ -42,8 +42,6 @@ class GridHeaderRow extends StatelessWidget {
 
     final now = DateTime.now();
     final today = DateTime(now.year, now.month, now.day);
-    final semesterStart = config.semesterStartDate;
-
     return Container(
       height: 40,
       decoration: BoxDecoration(
@@ -71,14 +69,7 @@ class GridHeaderRow extends StatelessWidget {
                 final dayOfWeek = showWeekend
                     ? (index == 0 ? 7 : index)
                     : index + 1;
-                // 周日在周一之前，dayOfWeek=7 时应为 -1 而非 6
-                final daysFromMonday = dayOfWeek == 7 ? -1 : dayOfWeek - 1;
-                final mondayOffset = (1 - semesterStart.weekday) % 7;
-                final date = semesterStart.add(
-                  Duration(
-                    days: (displayWeek - 1) * 7 + mondayOffset + daysFromMonday,
-                  ),
-                );
+                final date = config.dateForCourseDay(displayWeek, dayOfWeek);
                 final isToday = !showAllWeeks && date.isAtSameMomentAs(today);
                 final specialDay = !showAllWeeks
                     ? HolidayUtils.getSpecialDay(date)

--- a/lib/widgets/webview/download_options.dart
+++ b/lib/widgets/webview/download_options.dart
@@ -12,3 +12,13 @@ class DownloadOptions {
   // 下载管理器中的初始标签页
   final int initialTab;
 }
+
+Map<String, String> mergeDownloadHeaders(
+  Map<String, String>? configuredHeaders, {
+  required String? cookieHeader,
+}) {
+  return <String, String>{
+    ...?configuredHeaders,
+    if (cookieHeader != null && cookieHeader.isNotEmpty) 'Cookie': cookieHeader,
+  };
+}

--- a/lib/widgets/webview/webview_notice_handlers.dart
+++ b/lib/widgets/webview/webview_notice_handlers.dart
@@ -78,6 +78,26 @@ mixin WebViewNoticeHandlers<T extends StatefulWidget> on State<T> {
     });
   }
 
+  Future<String?> getDownloadCookieHeader(String url) async {
+    final cookies = await CookieManager.instance().getCookies(url: WebUri(url));
+    if (cookies.isEmpty) return null;
+    return cookies.map((c) => '${c.name}=${c.value}').join('; ');
+  }
+
+  Future<void> downloadNoticeFile(
+    String url,
+    String dirName,
+    String fileName, {
+    required Map<String, String> headers,
+  }) {
+    return getIt<DownloadManager>().download(
+      url,
+      dirName,
+      fileName,
+      headers: headers,
+    );
+  }
+
   Future<void> onDownloadAttachment(List<dynamic> args) async {
     if (downloadOptions == null) return;
     if (args.length < 2) return;
@@ -85,15 +105,11 @@ mixin WebViewNoticeHandlers<T extends StatefulWidget> on State<T> {
     final name = args[1] as String;
     final options = downloadOptions!;
     try {
-      final cookies = await CookieManager.instance().getCookies(
-        url: WebUri(url),
+      final headers = mergeDownloadHeaders(
+        options.downloadHeaders,
+        cookieHeader: await getDownloadCookieHeader(url),
       );
-      final headers = <String, String>{
-        ...options.downloadHeaders!,
-        if (cookies.isNotEmpty)
-          'Cookie': cookies.map((c) => '${c.name}=${c.value}').join('; '),
-      };
-      await getIt<DownloadManager>().download(
+      await downloadNoticeFile(
         url,
         options.attachmentDir,
         name,
@@ -115,23 +131,16 @@ mixin WebViewNoticeHandlers<T extends StatefulWidget> on State<T> {
     }
   }
 
-  Future<DownloadStartResponse?> onDownloadStarting(
-    InAppWebViewController controller,
-    DownloadStartRequest request,
-  ) async {
-    if (downloadOptions == null) return null;
-    final options = downloadOptions!;
+  Future<bool> handleDownloadStartRequest(DownloadStartRequest request) async {
+    final options = downloadOptions;
+    if (options == null) return false;
     final url = request.url.toString();
     try {
-      final cookies = await CookieManager.instance().getCookies(
-        url: WebUri(url),
+      final headers = mergeDownloadHeaders(
+        options.downloadHeaders,
+        cookieHeader: await getDownloadCookieHeader(url),
       );
-      final headers = <String, String>{
-        ...options.downloadHeaders!,
-        if (cookies.isNotEmpty)
-          'Cookie': cookies.map((c) => '${c.name}=${c.value}').join('; '),
-      };
-      await getIt<DownloadManager>().download(
+      await downloadNoticeFile(
         url,
         options.attachmentDir,
         request.suggestedFilename ?? 'download',
@@ -142,9 +151,20 @@ mixin WebViewNoticeHandlers<T extends StatefulWidget> on State<T> {
           context,
         ).showSnackBar(const SnackBar(content: Text('下载完成')));
       }
+      return true;
     } catch (e) {
       debugPrint('$debugLabel download error: $e');
+      return false;
     }
-    return DownloadStartResponse(handled: true);
+  }
+
+  Future<DownloadStartResponse?> onDownloadStarting(
+    InAppWebViewController controller,
+    DownloadStartRequest request,
+  ) async {
+    if (downloadOptions == null) return null;
+    return DownloadStartResponse(
+      handled: await handleDownloadStartRequest(request),
+    );
   }
 }

--- a/test/academic_calendar_page_test.dart
+++ b/test/academic_calendar_page_test.dart
@@ -37,6 +37,82 @@ void main() {
 
     expect(errors, isEmpty);
   });
+
+  testWidgets('keeps the selected detail when an older response arrives last', (
+    tester,
+  ) async {
+    final firstDetail = Completer<http.Response>();
+    final secondDetail = Completer<http.Response>();
+    final requestedPaths = <String>[];
+
+    Future<http.Response> httpGet(Uri uri) {
+      requestedPaths.add(uri.path);
+      if (uri.path.endsWith('/cdxl.htm')) {
+        return Future.value(
+          http.Response(
+            '<a href="info/1101/100.htm">2024-2025</a>'
+            '<a href="info/1101/200.htm">2025-2026</a>',
+            200,
+          ),
+        );
+      }
+      if (uri.path.endsWith('/100.htm')) return firstDetail.future;
+      if (uri.path.endsWith('/200.htm')) return secondDetail.future;
+      throw StateError('Unexpected request: $uri');
+    }
+
+    await tester.pumpWidget(
+      _testApp(
+        AcademicCalendarPage(
+          httpGet: httpGet,
+          interactiveDataLoader: () async =>
+              AcademicCalendarData(semesters: const []),
+          officialImageBuilder: (_, url) => Text(url, key: ValueKey(url)),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+    expect(requestedPaths, ['/cdxl.htm', '/info/1101/100.htm']);
+
+    final tabBar = tester.widget<TabBar>(find.byType(TabBar));
+    tabBar.controller!.animateTo(1, duration: Duration.zero);
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+
+    final dropdownFinder = find.byWidgetPredicate(
+      (widget) => widget is DropdownButton,
+      skipOffstage: false,
+    );
+    expect(dropdownFinder, findsOneWidget);
+    final dropdown = tester.widget<DropdownButton<dynamic>>(dropdownFinder);
+    final secondEntry = dropdown.items!.last.value;
+    dropdown.onChanged!(secondEntry);
+    await tester.pump();
+
+    const secondUrl = 'https://jwc.scu.edu.cn/__local/second.png';
+    secondDetail.complete(
+      http.Response('<img src="/__local/second.png">', 200),
+    );
+    await tester.pump();
+    expect(
+      find.byKey(const ValueKey(secondUrl), skipOffstage: false),
+      findsOneWidget,
+    );
+
+    const firstUrl = 'https://jwc.scu.edu.cn/__local/first.png';
+    firstDetail.complete(http.Response('<img src="/__local/first.png">', 200));
+    await tester.pump();
+
+    expect(
+      find.byKey(const ValueKey(secondUrl), skipOffstage: false),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey(firstUrl), skipOffstage: false),
+      findsNothing,
+    );
+  });
 }
 
 Widget _testApp(Widget home) {

--- a/test/academic_calendar_page_test.dart
+++ b/test/academic_calendar_page_test.dart
@@ -1,0 +1,48 @@
+import 'dart:async';
+
+import 'package:bugaoshan/l10n/app_localizations.dart';
+import 'package:bugaoshan/models/academic_calendar.dart';
+import 'package:bugaoshan/pages/campus/academic_calendar/academic_calendar_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+
+void main() {
+  testWidgets('ignores list and interactive responses after disposal', (
+    tester,
+  ) async {
+    final listResponse = Completer<http.Response>();
+    final interactiveResponse = Completer<AcademicCalendarData>();
+    final errors = <FlutterErrorDetails>[];
+    final previousOnError = FlutterError.onError;
+    FlutterError.onError = errors.add;
+    addTearDown(() => FlutterError.onError = previousOnError);
+
+    await tester.pumpWidget(
+      _testApp(
+        AcademicCalendarPage(
+          httpGet: (_) => listResponse.future,
+          interactiveDataLoader: () => interactiveResponse.future,
+        ),
+      ),
+    );
+    await tester.pump();
+
+    await tester.pumpWidget(_testApp(const SizedBox.shrink()));
+    listResponse.complete(
+      http.Response('<a href="info/1101/123.htm">2025-2026</a>', 200),
+    );
+    interactiveResponse.complete(AcademicCalendarData(semesters: const []));
+    await tester.pump();
+
+    expect(errors, isEmpty);
+  });
+}
+
+Widget _testApp(Widget home) {
+  return MaterialApp(
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: home,
+  );
+}

--- a/test/add_widget_picker_test.dart
+++ b/test/add_widget_picker_test.dart
@@ -54,7 +54,11 @@ void main() {
       MaterialApp(
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
-        home: const Scaffold(body: AddWidgetContent(showDescription: false)),
+        home: const Scaffold(
+          body: SingleChildScrollView(
+            child: AddWidgetContent(showDescription: false),
+          ),
+        ),
       ),
     );
 

--- a/test/auth_logger_test.dart
+++ b/test/auth_logger_test.dart
@@ -1,0 +1,30 @@
+import 'package:bugaoshan/utils/auth_logger.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AuthLogRedactor', () {
+    test('脱敏日志中的账号和用户标识', () {
+      final redacted = AuthLogRedactor.apply(
+        'login user=202612345678 userId=ccyl-user-42 username=alice',
+      );
+
+      expect(redacted, isNot(contains('202612345678')));
+      expect(redacted, isNot(contains('ccyl-user-42')));
+      expect(redacted, isNot(contains('alice')));
+      expect(redacted, contains('user=<redacted>'));
+      expect(redacted, contains('userId=<redacted>'));
+      expect(redacted, contains('username=<redacted>'));
+    });
+
+    test('保留原有凭据脱敏行为', () {
+      final redacted = AuthLogRedactor.apply(
+        'Authorization: Bearer secret.token "password":"plain"',
+      );
+
+      expect(redacted, contains('Bearer <redacted>'));
+      expect(redacted, contains('"password":"<redacted>"'));
+      expect(redacted, isNot(contains('secret.token')));
+      expect(redacted, isNot(contains('plain')));
+    });
+  });
+}

--- a/test/auth_scoped_indexed_stack_test.dart
+++ b/test/auth_scoped_indexed_stack_test.dart
@@ -1,0 +1,58 @@
+import 'package:bugaoshan/widgets/common/auth_scoped_indexed_stack.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('认证边界变化会销毁并重建缓存页面状态', (tester) async {
+    final authenticated = ValueNotifier<bool>(true);
+    var created = 0;
+    var disposed = 0;
+
+    Widget buildStack() {
+      return MaterialApp(
+        home: AuthScopedIndexedStack(
+          authListenable: authenticated,
+          isAuthenticated: () => authenticated.value,
+          visibleIds: const ['private-page'],
+          selectedIndex: 0,
+          pageBuilder: (_) =>
+              _LifecycleProbe(serial: ++created, onDispose: () => disposed++),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildStack());
+    expect(find.text('probe-1'), findsOneWidget);
+
+    authenticated.value = false;
+    await tester.pump();
+    expect(disposed, 1);
+    expect(find.text('probe-2'), findsOneWidget);
+
+    authenticated.value = true;
+    await tester.pump();
+    expect(disposed, 2);
+    expect(find.text('probe-3'), findsOneWidget);
+  });
+}
+
+class _LifecycleProbe extends StatefulWidget {
+  const _LifecycleProbe({required this.serial, required this.onDispose});
+
+  final int serial;
+  final VoidCallback onDispose;
+
+  @override
+  State<_LifecycleProbe> createState() => _LifecycleProbeState();
+}
+
+class _LifecycleProbeState extends State<_LifecycleProbe> {
+  @override
+  void dispose() {
+    widget.onDispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => Text('probe-${widget.serial}');
+}

--- a/test/balance_query_provider_test.dart
+++ b/test/balance_query_provider_test.dart
@@ -1,0 +1,91 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:bugaoshan/providers/balance_query_provider.dart';
+import 'package:bugaoshan/services/api/balance_query_service.dart';
+import 'package:bugaoshan/services/api/payapp_api_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test(
+    'removing an earlier binding preserves selection and clears balances',
+    () async {
+      final bindings = [_binding('A'), _binding('B'), _binding('C')];
+      SharedPreferences.setMockInitialValues({
+        'balance_query_binding': jsonEncode(
+          bindings.map((binding) => binding.toJson()).toList(),
+        ),
+        'balance_query_current_room': 1,
+      });
+      final prefs = await SharedPreferences.getInstance();
+      final provider = BalanceQueryProvider(prefs, _FakePayAppApiService());
+
+      await provider.queryElectricInfo();
+      await provider.queryAcInfo();
+      expect(provider.electricInfo, isNotNull);
+      expect(provider.acInfo, isNotNull);
+
+      await provider.removeBinding(0);
+
+      expect(provider.currentIndex, 0);
+      expect(provider.currentBinding?.roomNo, 'B');
+      expect(provider.electricInfo, isNull);
+      expect(provider.acInfo, isNull);
+      expect(prefs.getInt('balance_query_current_room'), 0);
+    },
+  );
+}
+
+RoomBinding _binding(String roomNo) => RoomBinding(
+  cusNo: 'cus-$roomNo',
+  cusName: 'name-$roomNo',
+  schoolCode: 'school',
+  schoolName: '校区',
+  regCode: 'building',
+  regName: '楼栋',
+  unitCode: 'unit',
+  unitName: '单元',
+  roomNo: roomNo,
+);
+
+class _FakePayAppApiService implements PayAppApiService {
+  @override
+  Future<List<CampusItem>> getCampus() async => const [];
+
+  @override
+  Future<List<BuildingItem>> getArchitecture(String schoolCode) async =>
+      const [];
+
+  @override
+  Future<List<UnitItem>> getUnit(String schoolCode, String regCode) async =>
+      const [];
+
+  @override
+  Future<RoomInfo> queryRoomInfo({
+    required String cusNo,
+    required int type,
+    required String cusName,
+  }) async => RoomInfo(
+    cusNo: cusNo,
+    cusName: cusName,
+    roomNo: 'room',
+    schoolName: '校区',
+    regName: '楼栋',
+    unitName: '单元',
+    price: '1',
+    balance: '10',
+  );
+
+  @override
+  Future<bool> verificationRoom({
+    required String cusNo,
+    required int type,
+    required String cusName,
+    required String schoolCode,
+    required String regCode,
+    required String unitCode,
+    required String roomNo,
+  }) async => true;
+}

--- a/test/ccyl_api_retry_test.dart
+++ b/test/ccyl_api_retry_test.dart
@@ -1,0 +1,126 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:bugaoshan/injection/injector.dart';
+import 'package:bugaoshan/pages/campus/ccyl/models/ccyl_models.dart';
+import 'package:bugaoshan/services/api/ccyl_api_service.dart';
+import 'package:bugaoshan/services/auth/ccyl_auth.dart';
+import 'package:bugaoshan/services/auth/scu_auth.dart';
+import 'package:bugaoshan/services/ccyl/ccyl_service.dart';
+import 'package:bugaoshan/utils/auth_logger.dart';
+
+void main() {
+  late SharedPreferences prefs;
+  late AuthLogger logger;
+
+  setUp(() async {
+    await getIt.reset();
+    logger = AuthLogger();
+    getIt.registerSingleton<AuthLogger>(logger);
+    FlutterSecureStorage.setMockInitialValues({});
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+  });
+
+  tearDown(() async {
+    await getIt.reset();
+  });
+
+  test('only CCYL business code 401 is classified as auth expiry', () {
+    expect(isCcylAuthExpiredCode(401), isTrue);
+    expect(isCcylAuthExpiredCode('401'), isTrue);
+    expect(isCcylAuthExpiredCode(400), isFalse);
+    expect(isCcylAuthExpiredCode(500), isFalse);
+    expect(isCcylAuthExpiredCode(null), isFalse);
+  });
+
+  test('ordinary business failure does not replay a write operation', () async {
+    var loginCalls = 0;
+    var oauthCalls = 0;
+    final auth = await _authenticatedCcylAuth(
+      prefs,
+      logger,
+      onLogin: () => loginCalls++,
+      onOAuth: () => oauthCalls++,
+    );
+    var operationCalls = 0;
+
+    await expectLater(
+      retryOnCcylAuthError(auth, () async {
+        operationCalls++;
+        throw const CcylException('报名人数已满');
+      }),
+      throwsA(isA<CcylException>()),
+    );
+
+    expect(operationCalls, 1);
+    expect(loginCalls, 1);
+    expect(oauthCalls, 0);
+  });
+
+  test(
+    'explicit auth expiry reauthenticates and retries exactly once',
+    () async {
+      var loginCalls = 0;
+      var oauthCalls = 0;
+      final auth = await _authenticatedCcylAuth(
+        prefs,
+        logger,
+        onLogin: () => loginCalls++,
+        onOAuth: () => oauthCalls++,
+      );
+      var operationCalls = 0;
+
+      final result = await retryOnCcylAuthError(auth, () async {
+        operationCalls++;
+        if (operationCalls == 1) {
+          throw const CcylAuthExpiredException('token失效，请重新登录');
+        }
+        return 'ok';
+      });
+
+      expect(result, 'ok');
+      expect(operationCalls, 2);
+      expect(loginCalls, 2);
+      expect(oauthCalls, 1);
+    },
+  );
+}
+
+Future<CcylAuth> _authenticatedCcylAuth(
+  SharedPreferences prefs,
+  AuthLogger logger, {
+  required void Function() onLogin,
+  required void Function() onOAuth,
+}) async {
+  final scuAuth = _PrincipalScuAuth(prefs, logger: logger);
+  final auth = CcylAuth(
+    scuAuth,
+    logger: logger,
+    oauthCodeProvider: () async {
+      onOAuth();
+      return 'refresh-code';
+    },
+    login: (_) async {
+      onLogin();
+      return (
+        token: 'token',
+        user: CcylUser(
+          id: 'ccyl-user',
+          userName: 'student-a',
+          realname: 'Student A',
+          orgName: 'SCU',
+        ),
+      );
+    },
+  );
+  await auth.loginWithCode('initial-code');
+  return auth;
+}
+
+class _PrincipalScuAuth extends ScuAuth {
+  _PrincipalScuAuth(super.prefs, {required super.logger});
+
+  @override
+  String? get principal => 'student-a';
+}

--- a/test/ccyl_auth_generation_test.dart
+++ b/test/ccyl_auth_generation_test.dart
@@ -1,0 +1,130 @@
+import 'dart:async';
+
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:bugaoshan/injection/injector.dart';
+import 'package:bugaoshan/pages/campus/ccyl/models/ccyl_models.dart';
+import 'package:bugaoshan/services/auth/ccyl_auth.dart';
+import 'package:bugaoshan/services/auth/scu_auth.dart';
+import 'package:bugaoshan/utils/auth_logger.dart';
+import 'package:bugaoshan/utils/secure_storage.dart';
+
+void main() {
+  late SharedPreferences prefs;
+  late AuthLogger logger;
+
+  setUp(() async {
+    await getIt.reset();
+    logger = AuthLogger();
+    getIt.registerSingleton<AuthLogger>(logger);
+    FlutterSecureStorage.setMockInitialValues({});
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+  });
+
+  tearDown(() async {
+    await getIt.reset();
+  });
+
+  test('invalidate prevents a pending reLogin from restoring token', () async {
+    final started = Completer<void>();
+    final response = Completer<CcylLoginResult>();
+    final auth = _pendingAuth(prefs, logger, started, response);
+
+    final pending = auth.reLogin();
+    await started.future;
+    auth.invalidate();
+    response.complete(_loginResult('old-token'));
+
+    expect(await pending, isFalse);
+    expect(auth.isLoggedIn, isFalse);
+    expect(auth.token, isNull);
+  });
+
+  test('logout prevents a pending reLogin from restoring storage', () async {
+    final started = Completer<void>();
+    final response = Completer<CcylLoginResult>();
+    final auth = _pendingAuth(prefs, logger, started, response);
+
+    final pending = auth.reLogin();
+    await started.future;
+    await auth.logout();
+    response.complete(_loginResult('old-token'));
+
+    expect(await pending, isFalse);
+    expect(auth.isLoggedIn, isFalse);
+    expect(
+      await SecureStorageProvider.instance.read(key: 'ccyl_session_v2'),
+      isNull,
+    );
+  });
+
+  test('an old reLogin cannot overwrite a newer successful login', () async {
+    final oldStarted = Completer<void>();
+    final newStarted = Completer<void>();
+    final oldResponse = Completer<CcylLoginResult>();
+    final newResponse = Completer<CcylLoginResult>();
+    var loginCalls = 0;
+    final auth = CcylAuth(
+      _PrincipalScuAuth(prefs, logger: logger),
+      logger: logger,
+      oauthCodeProvider: () async => 'oauth-code',
+      login: (_) {
+        loginCalls++;
+        if (loginCalls == 1) {
+          oldStarted.complete();
+          return oldResponse.future;
+        }
+        newStarted.complete();
+        return newResponse.future;
+      },
+    );
+
+    final oldLogin = auth.reLogin();
+    await oldStarted.future;
+    auth.invalidate();
+    final newLogin = auth.reLogin();
+    await newStarted.future;
+    newResponse.complete(_loginResult('new-token'));
+    expect(await newLogin, isTrue);
+
+    oldResponse.complete(_loginResult('old-token'));
+    expect(await oldLogin, isFalse);
+    expect(auth.token, 'new-token');
+  });
+}
+
+CcylAuth _pendingAuth(
+  SharedPreferences prefs,
+  AuthLogger logger,
+  Completer<void> started,
+  Completer<CcylLoginResult> response,
+) {
+  return CcylAuth(
+    _PrincipalScuAuth(prefs, logger: logger),
+    logger: logger,
+    oauthCodeProvider: () async => 'oauth-code',
+    login: (_) {
+      started.complete();
+      return response.future;
+    },
+  );
+}
+
+CcylLoginResult _loginResult(String token) => (
+  token: token,
+  user: CcylUser(
+    id: 'ccyl-user',
+    userName: 'student-a',
+    realname: 'Student A',
+    orgName: 'SCU',
+  ),
+);
+
+class _PrincipalScuAuth extends ScuAuth {
+  _PrincipalScuAuth(super.prefs, {required super.logger});
+
+  @override
+  String? get principal => 'student-a';
+}

--- a/test/ccyl_auth_principal_test.dart
+++ b/test/ccyl_auth_principal_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:bugaoshan/injection/injector.dart';
+import 'package:bugaoshan/pages/campus/ccyl/models/ccyl_models.dart';
+import 'package:bugaoshan/services/auth/ccyl_auth.dart';
+import 'package:bugaoshan/services/auth/scu_auth.dart';
+import 'package:bugaoshan/utils/auth_logger.dart';
+import 'package:bugaoshan/utils/secure_storage.dart';
+
+void main() {
+  late SharedPreferences prefs;
+  late AuthLogger logger;
+
+  setUp(() async {
+    await getIt.reset();
+    logger = AuthLogger();
+    getIt.registerSingleton<AuthLogger>(logger);
+    FlutterSecureStorage.setMockInitialValues({});
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+  });
+
+  tearDown(() async {
+    await getIt.reset();
+  });
+
+  test('does not restore principal A CCYL token for principal B', () async {
+    final scuAuth = _PrincipalScuAuth(
+      prefs,
+      logger: logger,
+      currentPrincipal: 'student-a',
+    );
+    final authForA = CcylAuth(
+      scuAuth,
+      logger: logger,
+      login: (_) async => (
+        token: 'token-a',
+        user: CcylUser(
+          id: 'ccyl-a',
+          userName: 'student-a',
+          realname: 'Student A',
+          orgName: 'SCU',
+        ),
+      ),
+    );
+
+    await authForA.loginWithCode('code-a');
+    expect(authForA.token, 'token-a');
+
+    scuAuth.currentPrincipal = 'student-b';
+    expect(authForA.isLoggedIn, isFalse);
+    expect(authForA.token, isNull);
+    expect(authForA.currentUser, isNull);
+
+    final authForB = CcylAuth(scuAuth, logger: logger);
+    await authForB.init();
+
+    expect(authForB.isLoggedIn, isFalse);
+    expect(authForB.token, isNull);
+    expect(
+      await SecureStorageProvider.instance.read(key: 'ccyl_session_v2'),
+      isNull,
+    );
+  });
+}
+
+class _PrincipalScuAuth extends ScuAuth {
+  String? currentPrincipal;
+
+  _PrincipalScuAuth(
+    super.prefs, {
+    required super.logger,
+    required this.currentPrincipal,
+  });
+
+  @override
+  String? get principal => currentPrincipal;
+}

--- a/test/class_schedule_inquiry_detail_test.dart
+++ b/test/class_schedule_inquiry_detail_test.dart
@@ -1,0 +1,83 @@
+import 'package:bugaoshan/injection/injector.dart';
+import 'package:bugaoshan/l10n/app_localizations.dart';
+import 'package:bugaoshan/pages/campus/class_schedule_inquiry/class_schedule_inquiry_detail_page.dart';
+import 'package:bugaoshan/pages/campus/models/class_schedule_inquiry_model.dart';
+import 'package:bugaoshan/providers/app_config_provider.dart';
+import 'package:bugaoshan/services/api/zhjw_api_service.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _FakeZhjwApiService implements ZhjwApiService {
+  @override
+  Future<List<ClassScheduleInquiryItem>> fetchClassSchedule({
+    required String planCode,
+    required String classCode,
+  }) async {
+    return [
+      ClassScheduleInquiryItem(
+        dayOfWeek: DateTime.sunday,
+        startPeriod: 1,
+        duration: 2,
+        courseCode: 'TEST001',
+        courseSeq: '01',
+        courseName: '周末课程',
+        teacherName: '测试教师',
+        weeksDescription: '1-16周',
+        campus: '江安',
+        building: '一教',
+        classroom: 'A101',
+      ),
+    ];
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  setUp(() async {
+    await getIt.reset();
+    SharedPreferences.setMockInitialValues({'showWeekend': false});
+    final prefs = await SharedPreferences.getInstance();
+    getIt.registerSingleton<AppConfigProvider>(AppConfigProvider(prefs));
+    getIt.registerSingleton<ZhjwApiService>(_FakeZhjwApiService());
+  });
+
+  tearDown(() async {
+    await getIt.reset();
+  });
+
+  testWidgets('班级详情局部显示周末但不修改全局偏好', (tester) async {
+    tester.view.physicalSize = const Size(1200, 1000);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: ClassScheduleInquiryDetailPage(
+          classInfo: ClassInfo(
+            planCode: 'PLAN',
+            classCode: 'CLASS',
+            planName: '测试培养方案',
+            className: '测试班级',
+            departmentName: '测试学院',
+            subjectName: '测试专业',
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final appConfig = getIt<AppConfigProvider>();
+    expect(appConfig.showWeekend.value, isFalse);
+
+    final l10n = AppLocalizations.of(
+      tester.element(find.byType(ClassScheduleInquiryDetailPage)),
+    )!;
+    expect(find.text(l10n.sunday), findsOneWidget);
+  });
+}

--- a/test/class_week_parser_test.dart
+++ b/test/class_week_parser_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:bugaoshan/models/course.dart';
+import 'package:bugaoshan/services/ics_service.dart';
+import 'package:bugaoshan/utils/class_week_parser.dart';
+import 'package:bugaoshan/widgets/course/grid_logic.dart';
+
+void main() {
+  group('classWeek parsing', () {
+    test('splits sparse weeks without filling gaps', () {
+      final segments = parseClassWeekSegments('110100');
+
+      expect(segments, [
+        (startWeek: 1, endWeek: 2, weekType: WeekType.every),
+        (startWeek: 4, endWeek: 4, weekType: WeekType.every),
+      ]);
+    });
+
+    test('keeps a complete alternating sequence compact', () {
+      expect(parseClassWeekSegments('101010'), [
+        (startWeek: 1, endWeek: 5, weekType: WeekType.odd),
+      ]);
+      expect(parseClassWeekSegments('010101'), [
+        (startWeek: 2, endWeek: 6, weekType: WeekType.even),
+      ]);
+    });
+
+    test('preserves active-week semantics in the grid and ICS export', () {
+      final segments = parseClassWeekSegments('110100');
+      final courses = segments.indexed.map((entry) {
+        final (index, segment) = entry;
+        return Course(
+          id: 'segment-$index',
+          name: '稀疏周课程',
+          teacher: '老师',
+          location: '教室',
+          startWeek: segment.startWeek,
+          endWeek: segment.endWeek,
+          dayOfWeek: DateTime.monday,
+          startSection: 1,
+          endSection: 1,
+          colorValue: 0xff2196f3,
+          weekType: segment.weekType,
+        );
+      }).toList();
+
+      final visibleByWeek = [
+        for (var week = 1; week <= 6; week++)
+          selectVisibleCoursesForDay(
+            courses,
+            week,
+            showNonCurrentWeekCourses: false,
+          ).isNotEmpty,
+      ];
+      expect(visibleByWeek, [true, true, false, true, false, false]);
+
+      final config = ScheduleConfig(
+        semesterStartDate: DateTime(2026, 1, 5),
+        timeSlots: const [
+          TimeSlot(
+            startTime: TimeOfDay(hour: 8, minute: 15),
+            endTime: TimeOfDay(hour: 9, minute: 0),
+          ),
+        ],
+      );
+      final eventDates = IcsService.genCourseCalendarEvents(
+        config: config,
+        courses: courses,
+        teacherLabel: '教师',
+      ).map((event) => event.start).toList();
+
+      expect(eventDates, [
+        DateTime(2026, 1, 5, 8, 15),
+        DateTime(2026, 1, 12, 8, 15),
+        DateTime(2026, 1, 26, 8, 15),
+      ]);
+    });
+  });
+}

--- a/test/cookie_client_test.dart
+++ b/test/cookie_client_test.dart
@@ -1,0 +1,128 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:bugaoshan/injection/injector.dart';
+import 'package:bugaoshan/services/auth/cookie_client.dart';
+import 'package:bugaoshan/utils/auth_logger.dart';
+
+void main() {
+  setUp(() async {
+    await getIt.reset();
+    getIt.registerSingleton<AuthLogger>(AuthLogger());
+  });
+
+  tearDown(() async {
+    await getIt.reset();
+  });
+
+  group('CookieClient.followRedirects sensitive headers', () {
+    test('keeps Authorization on relative same-origin redirects', () async {
+      final requests = <http.Request>[];
+      final client = CookieClient(
+        inner: MockClient((request) async {
+          requests.add(request);
+          if (request.url.path == '/start') {
+            return http.Response(
+              '',
+              302,
+              headers: {'location': '/next'},
+              request: request,
+            );
+          }
+          return http.Response('ok', 200, request: request);
+        }),
+      );
+
+      await client.followRedirects(
+        Uri.parse('https://id.scu.edu.cn/start'),
+        headers: {'Authorization': 'Bearer secret'},
+      );
+
+      expect(requests, hasLength(2));
+      expect(requests[0].headers['Authorization'], 'Bearer secret');
+      expect(requests[1].headers['Authorization'], 'Bearer secret');
+    });
+
+    test('drops Authorization on cross-origin redirects', () async {
+      final requests = <http.Request>[];
+      final client = CookieClient(
+        inner: MockClient((request) async {
+          requests.add(request);
+          if (request.url.host == 'id.scu.edu.cn') {
+            return http.Response(
+              '',
+              302,
+              headers: {'location': 'https://wfw.scu.edu.cn/oauth'},
+              request: request,
+            );
+          }
+          return http.Response('ok', 200, request: request);
+        }),
+      );
+
+      await client.followRedirects(
+        Uri.parse('https://id.scu.edu.cn/start'),
+        headers: {'Authorization': 'Bearer secret'},
+      );
+
+      expect(requests, hasLength(2));
+      expect(requests[0].headers['Authorization'], 'Bearer secret');
+      expect(requests[1].headers, isNot(contains('Authorization')));
+    });
+
+    test('drops Authorization on HTTPS to HTTP redirects', () async {
+      final requests = <http.Request>[];
+      final client = CookieClient(
+        inner: MockClient((request) async {
+          requests.add(request);
+          if (request.url.scheme == 'https') {
+            return http.Response(
+              '',
+              302,
+              headers: {'location': 'http://id.scu.edu.cn/next'},
+              request: request,
+            );
+          }
+          return http.Response('ok', 200, request: request);
+        }),
+      );
+
+      await client.followRedirects(
+        Uri.parse('https://id.scu.edu.cn/start'),
+        headers: {'Authorization': 'Bearer secret'},
+      );
+
+      expect(requests, hasLength(2));
+      expect(requests[1].headers, isNot(contains('Authorization')));
+    });
+
+    test('keeps Authorization for an explicitly allowed origin', () async {
+      final requests = <http.Request>[];
+      final client = CookieClient(
+        inner: MockClient((request) async {
+          requests.add(request);
+          if (request.url.host == 'id.scu.edu.cn') {
+            return http.Response(
+              '',
+              302,
+              headers: {'location': 'https://trusted.scu.edu.cn/next'},
+              request: request,
+            );
+          }
+          return http.Response('ok', 200, request: request);
+        }),
+      );
+
+      await client.followRedirects(
+        Uri.parse('https://id.scu.edu.cn/start'),
+        headers: {'Authorization': 'Bearer secret'},
+        sensitiveHeaderAllowedOrigins: {
+          Uri.parse('https://trusted.scu.edu.cn'),
+        },
+      );
+
+      expect(requests, hasLength(2));
+      expect(requests[1].headers['Authorization'], 'Bearer secret');
+    });
+  });
+}

--- a/test/download_manager_test.dart
+++ b/test/download_manager_test.dart
@@ -1,0 +1,65 @@
+import 'package:bugaoshan/services/download_manager.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('same file name from different URLs creates independent tasks', () {
+    final manager = DownloadManager();
+
+    final first = manager.enqueue(
+      'https://example.com/notices/1/attachment.pdf',
+      'notice_attachments',
+      'attachment.pdf',
+    );
+    final second = manager.enqueue(
+      'https://example.com/notices/2/attachment.pdf',
+      'notice_attachments',
+      'attachment.pdf',
+    );
+
+    expect(first, isNot(same(second)));
+    expect(manager.tasks, hasLength(2));
+    expect(
+      manager.taskFor(
+        'https://example.com/notices/1/attachment.pdf',
+        'notice_attachments',
+      ),
+      same(first),
+    );
+    expect(
+      manager.taskFor(
+        'https://example.com/notices/2/attachment.pdf',
+        'notice_attachments',
+      ),
+      same(second),
+    );
+  });
+
+  test('removing a downloaded path only removes its owning task', () {
+    final manager = DownloadManager();
+    final first = manager.enqueue(
+      'https://example.com/first',
+      'notice_attachments',
+      'attachment.pdf',
+    );
+    final second = manager.enqueue(
+      'https://example.com/second',
+      'notice_attachments',
+      'attachment.pdf',
+    );
+    manager.updateTask(
+      first,
+      status: DownloadStatus.done,
+      downloadedPath: '/downloads/attachment.pdf',
+    );
+    manager.updateTask(
+      second,
+      status: DownloadStatus.done,
+      downloadedPath: '/downloads/attachment (1).pdf',
+    );
+
+    manager.removeByDownloadedPath('/downloads/attachment (1).pdf');
+
+    expect(manager.tasks.values, contains(first));
+    expect(manager.tasks.values, isNot(contains(second)));
+  });
+}

--- a/test/download_path_index_test.dart
+++ b/test/download_path_index_test.dart
@@ -1,0 +1,108 @@
+import 'dart:io';
+
+import 'package:bugaoshan/pages/campus/downloads/file_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('download-path-index-');
+  });
+
+  tearDown(() async {
+    await tempDir.delete(recursive: true);
+  });
+
+  test('persists a distinct local path for each URL', () async {
+    final first = File('${tempDir.path}/attachment.pdf');
+    final second = File('${tempDir.path}/attachment (1).pdf');
+    await first.writeAsString('first');
+    await second.writeAsString('second');
+    final index = DownloadPathIndex(tempDir);
+
+    await index.record('https://example.com/first', first.path);
+    await index.record('https://example.com/second', second.path);
+
+    final reloaded = DownloadPathIndex(tempDir);
+    expect(
+      await reloaded.resolve(
+        'https://example.com/first',
+        legacyFileName: 'attachment.pdf',
+      ),
+      first.path,
+    );
+    expect(
+      await reloaded.resolve(
+        'https://example.com/second',
+        legacyFileName: 'attachment.pdf',
+      ),
+      second.path,
+    );
+  });
+
+  test('adopts each legacy file for at most one URL', () async {
+    final legacy = File('${tempDir.path}/attachment.pdf');
+    await legacy.writeAsString('legacy');
+    final index = DownloadPathIndex(tempDir);
+
+    expect(
+      await index.resolve(
+        'https://example.com/first',
+        legacyFileName: 'attachment.pdf',
+      ),
+      legacy.path,
+    );
+    expect(
+      await index.resolve(
+        'https://example.com/second',
+        legacyFileName: 'attachment.pdf',
+      ),
+      isNull,
+    );
+
+    final legacyVariant = File('${tempDir.path}/attachment (1).pdf');
+    await legacyVariant.writeAsString('second legacy');
+    expect(
+      await index.resolve(
+        'https://example.com/second',
+        legacyFileName: 'attachment.pdf',
+      ),
+      legacyVariant.path,
+    );
+  });
+
+  test('serializes concurrent legacy adoption', () async {
+    final legacy = File('${tempDir.path}/attachment.pdf');
+    await legacy.writeAsString('legacy');
+
+    final resolved = await Future.wait([
+      DownloadPathIndex(
+        tempDir,
+      ).resolve('https://example.com/first', legacyFileName: 'attachment.pdf'),
+      DownloadPathIndex(
+        tempDir,
+      ).resolve('https://example.com/second', legacyFileName: 'attachment.pdf'),
+    ]);
+
+    expect(resolved.where((path) => path == legacy.path), hasLength(1));
+    expect(resolved.where((path) => path == null), hasLength(1));
+  });
+
+  test('removes mappings that point at a deleted file', () async {
+    final file = File('${tempDir.path}/attachment.pdf');
+    await file.writeAsString('content');
+    final index = DownloadPathIndex(tempDir);
+    await index.record('https://example.com/attachment', file.path);
+
+    await index.removePath(file.path);
+
+    expect(
+      await index.resolve(
+        'https://example.com/attachment',
+        legacyFileName: 'missing.pdf',
+      ),
+      isNull,
+    );
+  });
+}

--- a/test/grades_provider_test.dart
+++ b/test/grades_provider_test.dart
@@ -1,0 +1,57 @@
+import 'package:bugaoshan/providers/grades_provider.dart';
+import 'package:bugaoshan/services/api/zhjw_api_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('grade caches are isolated when switching SCU accounts', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final api = _FakeZhjwApiService();
+    final provider = GradesProvider(prefs, api, initialUserId: 'account-A');
+
+    api.schemeData = _scoreData('A-scheme');
+    api.passingData = _scoreData('A-passing');
+    await provider.refreshSchemeScores();
+    await provider.refreshPassingScores();
+    expect(provider.schemeScores?.cjlx, 'A-scheme');
+    expect(provider.passingScores?.groups.single.label, 'A-passing');
+
+    provider.setUserIdentity('account-B');
+
+    expect(provider.schemeScores, isNull);
+    expect(provider.passingScores, isNull);
+    expect(provider.schemeState, GradesLoadState.idle);
+    expect(provider.passingState, GradesLoadState.idle);
+
+    final restartedAsB = GradesProvider(prefs, api, initialUserId: 'account-B');
+    expect(restartedAsB.schemeScores, isNull);
+    expect(restartedAsB.passingScores, isNull);
+
+    restartedAsB.setUserIdentity('account-A');
+    expect(restartedAsB.schemeScores?.cjlx, 'A-scheme');
+    expect(restartedAsB.passingScores?.groups.single.label, 'A-passing');
+  });
+}
+
+Map<String, dynamic> _scoreData(String label) => {
+  'lnList': [
+    {'cjlx': label, 'cjList': <Map<String, dynamic>>[]},
+  ],
+};
+
+class _FakeZhjwApiService implements ZhjwApiService {
+  late Map<String, dynamic> schemeData;
+  late Map<String, dynamic> passingData;
+
+  @override
+  Future<Map<String, dynamic>> fetchSchemeScores() async => schemeData;
+
+  @override
+  Future<Map<String, dynamic>> fetchPassingScores() async => passingData;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/test/grades_provider_test.dart
+++ b/test/grades_provider_test.dart
@@ -6,6 +6,27 @@ import 'package:shared_preferences/shared_preferences.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  test('grade cache identity requires a token-bound SCU principal', () {
+    expect(
+      GradesProvider.confirmedUserIdentity(isLoggedIn: true, principal: null),
+      isNull,
+    );
+    expect(
+      GradesProvider.confirmedUserIdentity(
+        isLoggedIn: false,
+        principal: 'account-A',
+      ),
+      isNull,
+    );
+    expect(
+      GradesProvider.confirmedUserIdentity(
+        isLoggedIn: true,
+        principal: ' account-A ',
+      ),
+      'account-A',
+    );
+  });
+
   test('grade caches are isolated when switching SCU accounts', () async {
     SharedPreferences.setMockInitialValues({});
     final prefs = await SharedPreferences.getInstance();

--- a/test/ics_service_test.dart
+++ b/test/ics_service_test.dart
@@ -5,6 +5,41 @@ import 'package:bugaoshan/services/ics_service.dart';
 
 void main() {
   group('Course calendar export', () {
+    test('aligns a Sunday semester boundary with the following Monday', () {
+      final config = ScheduleConfig(
+        semesterStartDate: DateTime(2026, 2, 22), // Sunday
+        semesterName: '2025-2026-2',
+        timeSlots: const [
+          TimeSlot(
+            startTime: TimeOfDay(hour: 8, minute: 15),
+            endTime: TimeOfDay(hour: 9, minute: 0),
+          ),
+        ],
+      );
+
+      Course course(String name, int dayOfWeek) => Course(
+        id: name,
+        name: name,
+        teacher: '老师',
+        location: '教室',
+        startWeek: 1,
+        endWeek: 1,
+        dayOfWeek: dayOfWeek,
+        startSection: 1,
+        endSection: 1,
+        colorValue: 0xff2196f3,
+      );
+
+      final events = IcsService.genCourseCalendarEvents(
+        config: config,
+        courses: [course('周一课程', 1), course('周日课程', 7)],
+        teacherLabel: '教师',
+      );
+
+      expect(events[0].start, DateTime(2026, 2, 23, 8, 15));
+      expect(events[1].start, DateTime(2026, 2, 22, 8, 15));
+    });
+
     test('keeps course title unchanged while mapping location', () {
       final config = ScheduleConfig(
         semesterStartDate: DateTime(2026, 2, 23),

--- a/test/payapp_session_expiry_test.dart
+++ b/test/payapp_session_expiry_test.dart
@@ -1,0 +1,115 @@
+import 'dart:convert';
+
+import 'package:bugaoshan/services/api/api_request.dart';
+import 'package:bugaoshan/services/api/balance_query_service.dart';
+import 'package:bugaoshan/services/auth/scu_exceptions.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+void main() {
+  const loginTimeoutHtml = '''
+    <!doctype html>
+    <html>
+      <head><title>登录超时</title></head>
+      <body>
+        <form action="/eleFees/oauth/airWarrant"></form>
+        <form action="/eleFees/oauth/lightWarrant"></form>
+      </body>
+    </html>
+  ''';
+  const campusJson =
+      '{"respCode":"00","data":{"datas":[{"name":"江安","code":"01"}]}}';
+
+  test('known PayApp login redirect is treated as unauthenticated', () async {
+    final client = MockClient(
+      (request) async => http.Response(
+        '',
+        302,
+        headers: {'location': 'http://payapp.scu.edu.cn/eleFees/index.html'},
+        request: request,
+      ),
+    );
+
+    await expectLater(
+      BalanceQueryService().getCampus(client),
+      throwsA(isA<UnauthenticatedException>()),
+    );
+  });
+
+  test('login timeout page triggers one authentication recovery', () async {
+    final clients = <http.Client>[
+      _responseClient(loginTimeoutHtml, contentType: 'text/html;charset=UTF-8'),
+      _responseClient(campusJson, contentType: 'application/json'),
+    ];
+    var getClientCalls = 0;
+    var invalidations = 0;
+    final service = BalanceQueryService();
+
+    final campus = await retryOnUnauthenticated(
+      () async => clients[getClientCalls++],
+      service.getCampus,
+      invalidate: () => invalidations++,
+    );
+
+    expect(campus.single.code, '01');
+    expect(getClientCalls, 2);
+    expect(invalidations, 1);
+  });
+
+  test('a second login timeout page is not retried indefinitely', () async {
+    final clients = <http.Client>[
+      _responseClient(loginTimeoutHtml, contentType: 'text/html'),
+      _responseClient(loginTimeoutHtml, contentType: 'text/html'),
+    ];
+    var getClientCalls = 0;
+    var invalidations = 0;
+    final service = BalanceQueryService();
+
+    await expectLater(
+      retryOnUnauthenticated(
+        () async => clients[getClientCalls++],
+        service.getCampus,
+        invalidate: () => invalidations++,
+      ),
+      throwsA(isA<UnauthenticatedException>()),
+    );
+    expect(getClientCalls, 2);
+    expect(invalidations, 1);
+  });
+
+  test('ordinary business HTML is not mistaken for session expiry', () async {
+    final client = _responseClient(
+      '<html><title>系统维护</title><body>请稍后再试</body></html>',
+      contentType: 'text/html',
+    );
+    var getClientCalls = 0;
+    var invalidations = 0;
+    final service = BalanceQueryService();
+
+    await expectLater(
+      retryOnUnauthenticated(
+        () async {
+          getClientCalls++;
+          return client;
+        },
+        service.getCampus,
+        invalidate: () => invalidations++,
+      ),
+      throwsA(isA<BalanceQueryException>()),
+    );
+    expect(getClientCalls, 1);
+    expect(invalidations, 0);
+  });
+}
+
+MockClient _responseClient(String body, {required String contentType}) {
+  return MockClient(
+    (request) async => http.Response.bytes(
+      utf8.encode(body),
+      200,
+      headers: {'content-type': contentType},
+      request: request,
+    ),
+  );
+}

--- a/test/plan_completion_provider_test.dart
+++ b/test/plan_completion_provider_test.dart
@@ -1,0 +1,64 @@
+import 'dart:async';
+
+import 'package:bugaoshan/pages/campus/plan_completion/models/plan_completion.dart';
+import 'package:bugaoshan/providers/plan_completion_provider.dart';
+import 'package:bugaoshan/services/api/zhjw_api_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test(
+    'an old account response cannot overwrite the new completion plan',
+    () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final api = _ControllableZhjwApiService();
+      final provider = PlanCompletionProvider(prefs, api);
+
+      final oldRequest = provider.fetchPlanCompletion(forceRefresh: true);
+      await provider.clearCache();
+      final newRequest = provider.fetchPlanCompletion(forceRefresh: true);
+
+      api.requests[1].complete([_node('new-account')]);
+      await newRequest;
+      expect(provider.nodes.single.id, 'new-account');
+
+      api.requests[0].complete([_node('old-account')]);
+      await oldRequest;
+
+      expect(provider.nodes.single.id, 'new-account');
+      expect(prefs.getString('plan_completion_nodes'), contains('new-account'));
+      expect(
+        prefs.getString('plan_completion_nodes'),
+        isNot(contains('old-account')),
+      );
+    },
+  );
+}
+
+PlanCompletionNode _node(String id) => PlanCompletionNode.fromJson({
+  'id': id,
+  'pId': '-1',
+  'flagId': id,
+  'flagType': '001',
+  'name': id,
+  'sfwc': '否',
+  'yxxf': '0',
+  'zsxf': '1',
+});
+
+class _ControllableZhjwApiService implements ZhjwApiService {
+  final requests = <Completer<List<PlanCompletionNode>>>[];
+
+  @override
+  Future<List<PlanCompletionNode>> fetchPlanCompletion() {
+    final request = Completer<List<PlanCompletionNode>>();
+    requests.add(request);
+    return request.future;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/test/scu_auth_test.dart
+++ b/test/scu_auth_test.dart
@@ -1,0 +1,119 @@
+import 'dart:async';
+
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:bugaoshan/injection/injector.dart';
+import 'package:bugaoshan/services/auth/cookie_client.dart';
+import 'package:bugaoshan/services/auth/scu_auth.dart';
+import 'package:bugaoshan/utils/auth_logger.dart';
+
+void main() {
+  late SharedPreferences prefs;
+  late AuthLogger logger;
+
+  setUp(() async {
+    await getIt.reset();
+    logger = AuthLogger();
+    getIt.registerSingleton<AuthLogger>(logger);
+    FlutterSecureStorage.setMockInitialValues({
+      'scu_access_token': 'stale-token',
+    });
+    SharedPreferences.setMockInitialValues({
+      'scu_login_timestamp': DateTime.now().millisecondsSinceEpoch ~/ 1000,
+    });
+    prefs = await SharedPreferences.getInstance();
+  });
+
+  tearDown(() async {
+    await getIt.reset();
+  });
+
+  for (final statusCode in [401, 403]) {
+    test(
+      'session/save $statusCode within local TTL uses one refresh for concurrent callers',
+      () async {
+        var sessionSaveCalls = 0;
+        final inner = MockClient((request) async {
+          sessionSaveCalls++;
+          if (sessionSaveCalls <= 2) {
+            return http.Response(
+              '{"error":"unauthorized"}',
+              statusCode,
+              request: request,
+            );
+          }
+          return http.Response('{"success":true}', 200, request: request);
+        });
+        final auth = _TestScuAuth(
+          prefs,
+          logger: logger,
+          cookieClientFactory: () => CookieClient(inner: inner),
+        );
+        await auth.init();
+
+        final first = auth.getClient();
+        final second = auth.getClient();
+        await auth.autoLoginStarted.future;
+        expect(auth.autoLoginCalls, 1);
+        auth.allowAutoLoginToFinish.complete();
+
+        final clients = await Future.wait([first, second]);
+        expect(identical(clients[0], clients[1]), isTrue);
+        expect(auth.autoLoginCalls, 1);
+        expect(sessionSaveCalls, 3);
+      },
+    );
+  }
+
+  test('invalid_token payload triggers refresh even with HTTP 200', () async {
+    var sessionSaveCalls = 0;
+    final inner = MockClient((request) async {
+      sessionSaveCalls++;
+      if (sessionSaveCalls <= 2) {
+        return http.Response(
+          '{"error":"invalid_token"}',
+          200,
+          request: request,
+        );
+      }
+      return http.Response('{"success":true}', 200, request: request);
+    });
+    final auth = _TestScuAuth(
+      prefs,
+      logger: logger,
+      cookieClientFactory: () => CookieClient(inner: inner),
+    );
+    await auth.init();
+
+    final clientFuture = auth.getClient();
+    await auth.autoLoginStarted.future;
+    auth.allowAutoLoginToFinish.complete();
+    await clientFuture;
+
+    expect(auth.autoLoginCalls, 1);
+    expect(sessionSaveCalls, 3);
+  });
+}
+
+class _TestScuAuth extends ScuAuth {
+  final autoLoginStarted = Completer<void>();
+  final allowAutoLoginToFinish = Completer<void>();
+  int autoLoginCalls = 0;
+
+  _TestScuAuth(
+    super.prefs, {
+    required super.logger,
+    required super.cookieClientFactory,
+  });
+
+  @override
+  Future<bool> autoLogin() async {
+    autoLoginCalls++;
+    if (!autoLoginStarted.isCompleted) autoLoginStarted.complete();
+    await allowAutoLoginToFinish.future;
+    return true;
+  }
+}

--- a/test/set_app_icon_page_test.dart
+++ b/test/set_app_icon_page_test.dart
@@ -1,0 +1,70 @@
+import 'dart:async';
+
+import 'package:bugaoshan/l10n/app_localizations.dart';
+import 'package:bugaoshan/pages/settings/set_app_icon_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  const channel = MethodChannel('bugaoshan/dynamic_icon');
+
+  tearDown(() async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+  });
+
+  testWidgets('ignores a successful icon load after disposal', (tester) async {
+    final icons = Completer<List<dynamic>>();
+    final currentIcon = Completer<String?>();
+    final calls = <String>[];
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) {
+          calls.add(call.method);
+          return switch (call.method) {
+            'getAvailableIcons' => icons.future,
+            'getCurrentIconName' => currentIcon.future,
+            _ => throw MissingPluginException(call.method),
+          };
+        });
+
+    await tester.pumpWidget(_testApp(const SetAppIconPage()));
+    await tester.pump();
+    icons.complete(<dynamic>['old']);
+    await tester.pump();
+    expect(calls, ['getAvailableIcons', 'getCurrentIconName']);
+
+    await tester.pumpWidget(_testApp(const SizedBox.shrink()));
+    currentIcon.complete('old');
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('ignores an icon loading error after disposal', (tester) async {
+    final icons = Completer<List<dynamic>>();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) {
+          if (call.method == 'getAvailableIcons') return icons.future;
+          throw MissingPluginException(call.method);
+        });
+
+    await tester.pumpWidget(_testApp(const SetAppIconPage()));
+    await tester.pump();
+    await tester.pumpWidget(_testApp(const SizedBox.shrink()));
+
+    icons.completeError(StateError('load failed'));
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+  });
+}
+
+Widget _testApp(Widget home) {
+  return MaterialApp(
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: home,
+  );
+}

--- a/test/share_utils_test.dart
+++ b/test/share_utils_test.dart
@@ -1,0 +1,39 @@
+import 'dart:ui';
+
+import 'package:bugaoshan/utils/share_utils.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('分享锚点来自触发控件的非零全局区域', (tester) async {
+    final anchorKey = GlobalKey();
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(child: SizedBox(key: anchorKey, width: 120, height: 60)),
+      ),
+    );
+
+    final origin = sharePositionOriginForContext(anchorKey.currentContext!);
+
+    expect(origin.width, 120);
+    expect(origin.height, 60);
+    expect(origin.isEmpty, isFalse);
+  });
+
+  testWidgets('调用方提供的有效锚点优先', (tester) async {
+    final anchorKey = GlobalKey();
+    const preferred = Rect.fromLTWH(10, 20, 30, 40);
+
+    await tester.pumpWidget(SizedBox(key: anchorKey, width: 100, height: 100));
+
+    expect(
+      sharePositionOriginForContext(
+        anchorKey.currentContext!,
+        preferred: preferred,
+      ),
+      preferred,
+    );
+  });
+}

--- a/test/share_utils_test.dart
+++ b/test/share_utils_test.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import 'package:bugaoshan/utils/share_utils.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/test/train_program_provider_test.dart
+++ b/test/train_program_provider_test.dart
@@ -1,0 +1,78 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:bugaoshan/pages/campus/train_program/models/train_program.dart';
+import 'package:bugaoshan/providers/train_program_provider.dart';
+import 'package:bugaoshan/services/api/zhjw_api_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('stale program detail cannot overwrite the latest request', () async {
+    final api = _ControllableZhjwApiService();
+    final provider = TrainProgramProvider(api);
+
+    final staleRequest = provider.fetchProgramDetail('old');
+    provider.clearDetail();
+    final latestRequest = provider.fetchProgramDetail('new');
+
+    api.programRequests['new']!.complete(_programDetail('new'));
+    await latestRequest;
+    expect(provider.currentDetail?.title, 'new');
+    expect(provider.detailState, TrainProgramLoadState.loaded);
+
+    api.programRequests['old']!.complete(_programDetail('old'));
+    await staleRequest;
+    expect(provider.currentDetail?.title, 'new');
+    expect(provider.detailState, TrainProgramLoadState.loaded);
+  });
+
+  test('stale course detail cannot overwrite the latest request', () async {
+    final api = _ControllableZhjwApiService();
+    final provider = TrainProgramProvider(api);
+
+    final staleRequest = provider.fetchCourseDetail('/old');
+    provider.clearCourseDetail();
+    final latestRequest = provider.fetchCourseDetail('/new');
+
+    api.courseRequests['/new']!.complete(_courseDetail('new'));
+    await latestRequest;
+    expect(provider.currentCourseDetail?.kc.kcm, 'new');
+    expect(provider.courseDetailState, TrainProgramLoadState.loaded);
+
+    api.courseRequests['/old']!.complete(_courseDetail('old'));
+    await staleRequest;
+    expect(provider.currentCourseDetail?.kc.kcm, 'new');
+    expect(provider.courseDetailState, TrainProgramLoadState.loaded);
+  });
+}
+
+TrainProgramDetail _programDetail(String title) =>
+    TrainProgramDetail.fromJson({'title': title});
+
+CourseDetail _courseDetail(String name) => CourseDetail.fromJson({
+  'flag': '1',
+  'kc': {'kcm': name},
+});
+
+class _ControllableZhjwApiService implements ZhjwApiService {
+  final programRequests = <String, Completer<TrainProgramDetail>>{};
+  final courseRequests = <String, Completer<CourseDetail>>{};
+
+  @override
+  Future<TrainProgramDetail> fetchProgramDetail(String fajhh) {
+    final completer = Completer<TrainProgramDetail>();
+    programRequests[fajhh] = completer;
+    return completer.future;
+  }
+
+  @override
+  Future<CourseDetail> fetchCourseDetail(String urlPath) {
+    final completer = Completer<CourseDetail>();
+    courseRequests[urlPath] = completer;
+    return completer.future;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/test/update_asset_selector_test.dart
+++ b/test/update_asset_selector_test.dart
@@ -1,0 +1,56 @@
+import 'package:bugaoshan/services/update_asset_selector.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const splitAssets = [
+    {
+      'name': 'bugaoshan_2.2.0_arm64-v8a.apk',
+      'browser_download_url': 'https://example.com/arm64.apk',
+    },
+    {
+      'name': 'bugaoshan_2.2.0_armeabi-v7a.apk',
+      'browser_download_url': 'https://example.com/armv7.apk',
+    },
+    {
+      'name': 'bugaoshan_2.2.0_x86_64.apk',
+      'browser_download_url': 'https://example.com/x64.apk',
+    },
+  ];
+
+  test('Android selects the universal APK even when splits come first', () {
+    final selected = selectUpdateAsset([
+      ...splitAssets,
+      {
+        'name': 'bugaoshan_2.2.0_universal.apk',
+        'browser_download_url': 'https://example.com/universal.apk',
+      },
+    ], UpdateAssetPlatform.android);
+
+    expect(selected?['name'], 'bugaoshan_2.2.0_universal.apk');
+  });
+
+  test('Android never falls back to an ABI split APK', () {
+    final selected = selectUpdateAsset(
+      splitAssets,
+      UpdateAssetPlatform.android,
+    );
+
+    expect(selected, isNull);
+  });
+
+  test('desktop platforms retain their archive selection', () {
+    const assets = [
+      {'name': 'bugaoshan_2.2.0_linux_x64.tar.gz'},
+      {'name': 'bugaoshan_2.2.0_windows_x64.zip'},
+    ];
+
+    expect(
+      selectUpdateAsset(assets, UpdateAssetPlatform.windows)?['name'],
+      'bugaoshan_2.2.0_windows_x64.zip',
+    );
+    expect(
+      selectUpdateAsset(assets, UpdateAssetPlatform.linux)?['name'],
+      'bugaoshan_2.2.0_linux_x64.tar.gz',
+    );
+  });
+}

--- a/test/user_info_provider_test.dart
+++ b/test/user_info_provider_test.dart
@@ -66,6 +66,58 @@ void main() {
     expect(provider.labels?.single['owner'], 'new-number');
     expect(provider.loading, isFalse);
   });
+
+  test('logout cleanup runs after an in-progress user cache write', () async {
+    final auth = _FakeWfwAuth(ready: true);
+    final api = _ControllableWfwApiService();
+    final persistence = _ControllableUserInfoPersistence();
+    UserInfoProvider(auth, api, persistUserInfo: persistence.call);
+    await Future<void>.delayed(Duration.zero);
+
+    api.complete(0, name: 'old-name', number: 'old-number');
+    await Future<void>.delayed(Duration.zero);
+    expect(persistence.requests, hasLength(1));
+    expect(persistence.requests.single.realname, 'old-name');
+
+    auth.setReady(false);
+    await Future<void>.delayed(Duration.zero);
+
+    // 清理必须排在旧写入之后，不能和它并发后被旧值反向覆盖。
+    expect(persistence.requests, hasLength(1));
+    persistence.complete(0);
+    await Future<void>.delayed(Duration.zero);
+    expect(persistence.requests, hasLength(2));
+    expect(persistence.requests[1].realname, isNull);
+    expect(persistence.requests[1].number, isNull);
+
+    persistence.complete(1);
+    await Future<void>.delayed(Duration.zero);
+    expect(persistence.storedRealname, isNull);
+    expect(persistence.storedNumber, isNull);
+  });
+}
+
+typedef _PersistenceRequest = ({
+  String? realname,
+  String? number,
+  Completer<void> completer,
+});
+
+class _ControllableUserInfoPersistence {
+  final requests = <_PersistenceRequest>[];
+  String? storedRealname;
+  String? storedNumber;
+
+  Future<void> call(String? realname, String? number) {
+    final completer = Completer<void>();
+    requests.add((realname: realname, number: number, completer: completer));
+    return completer.future.then((_) {
+      storedRealname = realname;
+      storedNumber = number;
+    });
+  }
+
+  void complete(int index) => requests[index].completer.complete();
 }
 
 class _FakeWfwAuth extends ChangeNotifier implements WfwAuth {

--- a/test/user_info_provider_test.dart
+++ b/test/user_info_provider_test.dart
@@ -1,0 +1,129 @@
+import 'dart:async';
+
+import 'package:bugaoshan/injection/injector.dart';
+import 'package:bugaoshan/providers/scu_auth_provider.dart';
+import 'package:bugaoshan/providers/user_info_provider.dart';
+import 'package:bugaoshan/services/api/wfw_api_service.dart';
+import 'package:bugaoshan/services/auth/auth_state.dart';
+import 'package:bugaoshan/services/auth/wfw_auth.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    await getIt.reset();
+    SharedPreferences.setMockInitialValues({});
+    getIt.registerSingleton<SharedPreferences>(
+      await SharedPreferences.getInstance(),
+    );
+    getIt.registerSingleton<ScuAuthProvider>(_FakeScuAuthProvider());
+  });
+
+  tearDown(() async {
+    await getIt.reset();
+  });
+
+  test('a response completed after logout cannot restore user data', () async {
+    final auth = _FakeWfwAuth(ready: true);
+    final api = _ControllableWfwApiService();
+    final provider = UserInfoProvider(auth, api);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(api.profileRequests, hasLength(1));
+    auth.setReady(false);
+    api.complete(0, name: 'old-name', number: 'old-number');
+    await Future<void>.delayed(Duration.zero);
+
+    expect(provider.userRealname, isNull);
+    expect(provider.userNumber, isNull);
+    expect(provider.labels, isNull);
+    expect(provider.loading, isFalse);
+  });
+
+  test('an older account response cannot overwrite the new account', () async {
+    final auth = _FakeWfwAuth(ready: true);
+    final api = _ControllableWfwApiService();
+    final provider = UserInfoProvider(auth, api);
+    await Future<void>.delayed(Duration.zero);
+
+    auth.setReady(false);
+    auth.setReady(true);
+    await Future<void>.delayed(const Duration(milliseconds: 350));
+    expect(api.profileRequests, hasLength(2));
+
+    api.complete(1, name: 'new-name', number: 'new-number');
+    await Future<void>.delayed(Duration.zero);
+    expect(provider.userNumber, 'new-number');
+
+    api.complete(0, name: 'old-name', number: 'old-number');
+    await Future<void>.delayed(Duration.zero);
+
+    expect(provider.userRealname, 'new-name');
+    expect(provider.userNumber, 'new-number');
+    expect(provider.labels?.single['owner'], 'new-number');
+    expect(provider.loading, isFalse);
+  });
+}
+
+class _FakeWfwAuth extends ChangeNotifier implements WfwAuth {
+  _FakeWfwAuth({required bool ready}) : _ready = ready;
+
+  bool _ready;
+
+  @override
+  bool get isReady => _ready;
+
+  @override
+  AuthState get state => _ready ? AuthState.ready : AuthState.unknown;
+
+  void setReady(bool value) {
+    _ready = value;
+    notifyListeners();
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _ControllableWfwApiService implements WfwApiService {
+  final profileRequests = <Completer<Map<String, dynamic>?>>[];
+  final labelRequests = <Completer<List<Map<String, dynamic>>>>[];
+
+  @override
+  Future<Map<String, dynamic>?> fetchUserProfile() {
+    final request = Completer<Map<String, dynamic>?>();
+    profileRequests.add(request);
+    return request.future;
+  }
+
+  @override
+  Future<List<Map<String, dynamic>>> fetchProfileLabels() {
+    final request = Completer<List<Map<String, dynamic>>>();
+    labelRequests.add(request);
+    return request.future;
+  }
+
+  void complete(int index, {required String name, required String number}) {
+    profileRequests[index].complete({
+      'realname': name,
+      'role': {'number': number},
+    });
+    labelRequests[index].complete([
+      {'owner': number},
+    ]);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeScuAuthProvider implements ScuAuthProvider {
+  @override
+  void setUserInfo(String? realname, String? number) {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/test/webview_notice_handlers_test.dart
+++ b/test/webview_notice_handlers_test.dart
@@ -1,0 +1,103 @@
+import 'package:bugaoshan/pages/campus/downloads/shared_notice_downloads.dart';
+import 'package:bugaoshan/widgets/webview/download_options.dart';
+import 'package:bugaoshan/widgets/webview/webview_notice_handlers.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('mergeDownloadHeaders', () {
+    test('allows omitted configured headers', () {
+      expect(mergeDownloadHeaders(null, cookieHeader: null), isEmpty);
+    });
+
+    test('adds cookies without mutating configured headers', () {
+      const configured = {'Referer': 'https://example.com'};
+
+      final headers = mergeDownloadHeaders(
+        configured,
+        cookieHeader: 'session=abc',
+      );
+
+      expect(headers, {
+        'Referer': 'https://example.com',
+        'Cookie': 'session=abc',
+      });
+      expect(configured, {'Referer': 'https://example.com'});
+    });
+  });
+
+  group('WebViewNoticeHandlers download callback', () {
+    test('handles a download when headers are omitted', () async {
+      final state = _TestNoticeState();
+
+      final handled = await state.handleDownloadStartRequest(_request());
+
+      expect(handled, isTrue);
+      expect(state.downloadedHeaders, isEmpty);
+    });
+
+    test('does not claim a failed download was handled', () async {
+      final state = _TestNoticeState(downloadError: Exception('failed'));
+
+      final handled = await state.handleDownloadStartRequest(_request());
+
+      expect(handled, isFalse);
+    });
+  });
+}
+
+DownloadStartRequest _request() => DownloadStartRequest(
+  contentLength: 1,
+  suggestedFilename: 'attachment.pdf',
+  url: WebUri('https://example.com/attachment.pdf'),
+);
+
+class _TestNoticeWidget extends StatefulWidget {
+  const _TestNoticeWidget();
+
+  @override
+  State<_TestNoticeWidget> createState() => _TestNoticeState();
+}
+
+class _TestNoticeState extends State<_TestNoticeWidget>
+    with WebViewNoticeHandlers<_TestNoticeWidget> {
+  _TestNoticeState({this.downloadError});
+
+  final Object? downloadError;
+  Map<String, String>? downloadedHeaders;
+  List<AttachItem> _attachments = const [];
+
+  @override
+  InAppWebViewController? get controller => null;
+
+  @override
+  String get debugLabel => 'TestNotice';
+
+  @override
+  DownloadOptions get downloadOptions =>
+      const DownloadOptions(attachmentDir: 'test', initialTab: 0);
+
+  @override
+  List<AttachItem> get pageAttachments => _attachments;
+
+  @override
+  set pageAttachments(List<AttachItem> value) => _attachments = value;
+
+  @override
+  Future<String?> getDownloadCookieHeader(String url) async => null;
+
+  @override
+  Future<void> downloadNoticeFile(
+    String url,
+    String dirName,
+    String fileName, {
+    required Map<String, String> headers,
+  }) async {
+    downloadedHeaders = headers;
+    if (downloadError case final error?) throw error;
+  }
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}

--- a/test/wfw_auth_test.dart
+++ b/test/wfw_auth_test.dart
@@ -1,0 +1,114 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:bugaoshan/injection/injector.dart';
+import 'package:bugaoshan/services/api/wfw_api_service.dart';
+import 'package:bugaoshan/services/auth/cookie_client.dart';
+import 'package:bugaoshan/services/auth/scu_auth.dart';
+import 'package:bugaoshan/services/auth/wfw_auth.dart';
+import 'package:bugaoshan/utils/auth_logger.dart';
+
+void main() {
+  late SharedPreferences prefs;
+  late AuthLogger logger;
+
+  setUp(() async {
+    await getIt.reset();
+    logger = AuthLogger();
+    getIt.registerSingleton<AuthLogger>(logger);
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+  });
+
+  tearDown(() async {
+    await getIt.reset();
+  });
+
+  test('warms WFW again when ScuAuth returns a new client', () async {
+    var firstWarmUps = 0;
+    var secondWarmUps = 0;
+    final firstClient = CookieClient(
+      inner: MockClient((request) async {
+        firstWarmUps++;
+        return http.Response('first ready', 200, request: request);
+      }),
+    );
+    final secondClient = CookieClient(
+      inner: MockClient((request) async {
+        secondWarmUps++;
+        return http.Response('second ready', 200, request: request);
+      }),
+    );
+    final scuAuth = _SwitchableScuAuth(
+      prefs,
+      logger: logger,
+      client: firstClient,
+    );
+    final wfwAuth = WfwAuth(scuAuth, logger: logger);
+
+    expect(await wfwAuth.getClient(), same(firstClient));
+    expect(firstWarmUps, 1);
+    expect(wfwAuth.isReady, isTrue);
+
+    scuAuth.client = secondClient;
+    expect(await wfwAuth.getClient(), same(secondClient));
+    expect(secondWarmUps, 1);
+    expect(wfwAuth.isReady, isTrue);
+
+    wfwAuth.dispose();
+  });
+
+  test('e=10013 invalidates, warms WFW, and retries once', () async {
+    var warmUps = 0;
+    var profileRequests = 0;
+    final client = CookieClient(
+      inner: MockClient((request) async {
+        if (request.url.path == '/') {
+          warmUps++;
+          return http.Response('ready', 200, request: request);
+        }
+        if (request.url.path == '/uc/wap/user/get-info') {
+          profileRequests++;
+          if (profileRequests == 1) {
+            return http.Response(
+              '{"e":10013,"m":"session expired"}',
+              200,
+              request: request,
+            );
+          }
+          return http.Response(
+            '{"e":0,"d":{"base":{"realname":"Test User"}}}',
+            200,
+            request: request,
+          );
+        }
+        return http.Response('not found', 404, request: request);
+      }),
+    );
+    final scuAuth = _SwitchableScuAuth(prefs, logger: logger, client: client);
+    final wfwAuth = WfwAuth(scuAuth, logger: logger);
+    final api = WfwApiService(wfwAuth);
+
+    final profile = await api.fetchUserProfile();
+
+    expect(profile?['realname'], 'Test User');
+    expect(profileRequests, 2);
+    expect(warmUps, 2);
+
+    wfwAuth.dispose();
+  });
+}
+
+class _SwitchableScuAuth extends ScuAuth {
+  CookieClient client;
+
+  _SwitchableScuAuth(
+    super.prefs, {
+    required super.logger,
+    required this.client,
+  });
+
+  @override
+  Future<CookieClient> getClient() async => client;
+}


### PR DESCRIPTION
## 背景

本 PR 基于 `upstream/main` 进行多线程代码审计，逐一复现并修复认证、并发状态、数据解析、下载更新和发布链路中的独立问题。每个问题均保持为独立提交，并在提交正文中使用中文记录“问题分析 / 解决方案 / 验证”。

## 主要变更

- 加固统一认证、WFW、CCYL 与 PayApp 会话：限制跨源重定向敏感请求头、识别服务端撤销 token、按校园账号隔离 token/缓存/页面状态，并避免过期登录或普通业务错误错误地恢复、重试会话。
- 修复异步竞态：培养方案、用户信息、计划完成度、官方校历和应用图标只接受当前请求结果，并串行化用户信息缓存写入。
- 修正课程与状态数据：统一周日起点的日期及 ICS 计算、保留稀疏周次、避免班级课表修改全局周末偏好，并保持删除房间后的有效选择。
- 修复附件与 WebView 下载：兼容空请求头、失败时不误报已处理，并按 URL 隔离同名附件及持久化路径。
- 完善跨平台更新与发布：Android 自动更新选择 universal APK，主发布流程纳入 Linux 制品，并补齐相关发布脚本测试。
- 修复 iPad 分享锚点、认证边界页面缓存、Android 小组件空课表选择等平台问题。

## 影响

这些修复可避免跨账号数据串用、旧异步响应覆盖新状态、认证刷新循环、课程日期偏移、附件互相覆盖、自动更新选错 APK，以及 Linux 发布制品缺失等用户可见问题。

## 验证

- `flutter test --no-pub`：103/103 通过。
- `.github/scripts/test_release_prepare.py`：2/2 通过。
- `.github/scripts/tests/test_release_workflow.py`：1/1 通过。
- `WidgetCourseSelectionTest`：Gradle/Kotlin 测试通过。
- `flutter analyze --no-pub`：本 PR 新增诊断为 0；现有 6 条均来自未修改的上游生成文件/工具脚本。
- `git diff --check upstream/main...HEAD`：通过。

## 范围说明

本 PR 不增加 Android、iOS 或 macOS 相册权限；相关必要性与官方平台文档依据仅在 #142 中讨论。
